### PR TITLE
Add a retain field for createSibling and createChild

### DIFF
--- a/packages/prisma-extension-bark/src/create/create-child.js
+++ b/packages/prisma-extension-bark/src/create/create-child.js
@@ -1,5 +1,5 @@
 import { Prisma } from '@prisma/client/extension'
-import { has_nullish, has_retain_columns, int2str } from "../utils.js";
+import { has_nullish, has_retain_columns, int2str } from '../utils.js'
 
 /**
  * @template T - Model
@@ -10,14 +10,14 @@ import { has_nullish, has_retain_columns, int2str } from "../utils.js";
  * @returns {Promise<import('$types/create.d.ts').createChildResult<T, A>>}
  */
 export default async function ({ node, data, retain, ...args }) {
-	const ctx = Prisma.getExtensionContext(this);
+	const ctx = Prisma.getExtensionContext(this)
 
 	/** @type {string} */
-	let path = node?.path;
+	let path = node?.path
 	/** @type {number} */
-	let depth = node?.depth;
+	let depth = node?.depth
 	/** @type {number} */
-	let numchild = node?.numchild;
+	let numchild = node?.numchild
 
 	// Get required arguments from instance
 	if (has_nullish(path, depth, numchild)) {
@@ -28,11 +28,11 @@ export default async function ({ node, data, retain, ...args }) {
 				depth: true,
 				numchild: true,
 			},
-		});
+		})
 		if (target) {
-			path = target.path;
-			depth = target.depth;
-			numchild = target.numchild;
+			path = target.path
+			depth = target.depth
+			numchild = target.numchild
 		}
 	}
 
@@ -47,24 +47,24 @@ export default async function ({ node, data, retain, ...args }) {
 				},
 				take: 1,
 			})
-			.then(([c]) => c);
+			.then(([c]) => c)
 
 		return ctx.createSibling({
 			node: child,
 			retain,
 			data,
 			...args,
-		});
+		})
 	} else {
 		// node hasn't had any kid, so adding first one
-		const new_step = int2str(1);
-		const new_path = path + new_step;
+		const new_step = int2str(1)
+		const new_path = path + new_step
 
 		let update_data = {
 			numchild: {
 				increment: 1,
 			},
-		};
+		}
 
 		// Check for fields to retain
 		if (has_retain_columns(retain)) {
@@ -73,10 +73,10 @@ export default async function ({ node, data, retain, ...args }) {
 					path: path,
 				},
 				select: retain,
-			});
+			})
 
 			if (old_data !== null)
-				update_data = { ...update_data, ...old_data };
+				update_data = { ...update_data, ...old_data }
 		}
 
 		const [newborn] = await ctx.__$transaction([
@@ -96,8 +96,8 @@ export default async function ({ node, data, retain, ...args }) {
 				},
 				data: update_data,
 			}),
-		]);
+		])
 
-		return newborn;
+		return newborn
 	}
 }

--- a/packages/prisma-extension-bark/src/create/create-child.js
+++ b/packages/prisma-extension-bark/src/create/create-child.js
@@ -1,5 +1,5 @@
 import { Prisma } from '@prisma/client/extension'
-import { has_nullish, int2str } from '../utils.js'
+import { has_nullish, has_retain_columns, int2str } from "../utils.js";
 
 /**
  * @template T - Model
@@ -9,15 +9,15 @@ import { has_nullish, int2str } from '../utils.js'
  * @param {import('$types/create.d.ts').createChildArgs<T, A>} args
  * @returns {Promise<import('$types/create.d.ts').createChildResult<T, A>>}
  */
-export default async function ({ node, data, ...args }) {
-	const ctx = Prisma.getExtensionContext(this)
+export default async function ({ node, data, retain, ...args }) {
+	const ctx = Prisma.getExtensionContext(this);
 
 	/** @type {string} */
-	let path = node?.path
+	let path = node?.path;
 	/** @type {number} */
-	let depth = node?.depth
+	let depth = node?.depth;
 	/** @type {number} */
-	let numchild = node?.numchild
+	let numchild = node?.numchild;
 
 	// Get required arguments from instance
 	if (has_nullish(path, depth, numchild)) {
@@ -26,36 +26,58 @@ export default async function ({ node, data, ...args }) {
 			select: {
 				path: true,
 				depth: true,
-				numchild: true
-			}
-		})
+				numchild: true,
+			},
+		});
 		if (target) {
-			path = target.path
-			depth = target.depth
-			numchild = target.numchild
+			path = target.path;
+			depth = target.depth;
+			numchild = target.numchild;
 		}
 	}
 
 	// if already has kids
 	if (numchild !== 0) {
-		const child = await ctx.findChildren({
-			node: {path, depth, numchild},
-			select: {
-				path: true,
-				depth: true
-			},
-			take: 1
-		}).then(([c]) => c)
+		const child = await ctx
+			.findChildren({
+				node: { path, depth, numchild },
+				select: {
+					path: true,
+					depth: true,
+				},
+				take: 1,
+			})
+			.then(([c]) => c);
 
 		return ctx.createSibling({
 			node: child,
+			retain,
 			data,
-			...args
-		})
+			...args,
+		});
 	} else {
 		// node hasn't had any kid, so adding first one
-		const new_step = int2str(1)
-		const new_path = path + new_step
+		const new_step = int2str(1);
+		const new_path = path + new_step;
+
+		let update_data = {
+			numchild: {
+				increment: 1,
+			},
+		};
+
+		// Check for fields to retain
+		if (has_retain_columns(retain)) {
+			const old_data = await ctx.findUnique({
+				where: {
+					path: path,
+				},
+				select: retain,
+			});
+
+			if (old_data !== null)
+				update_data = { ...update_data, ...old_data };
+		}
 
 		const [newborn] = await ctx.__$transaction([
 			ctx.create({
@@ -63,23 +85,19 @@ export default async function ({ node, data, ...args }) {
 					...data,
 					path: new_path,
 					depth: depth + 1,
-					numchild: 0
+					numchild: 0,
 				},
-				...args
+				...args,
 			}),
 			// update parent numchild
 			ctx.update({
 				where: {
-					path: path
+					path: path,
 				},
-				data: {
-					numchild: {
-						increment: 1
-					}
-				}
-			})
-		])
+				data: update_data,
+			}),
+		]);
 
-		return newborn
+		return newborn;
 	}
 }

--- a/packages/prisma-extension-bark/src/create/create-sibling.js
+++ b/packages/prisma-extension-bark/src/create/create-sibling.js
@@ -4,7 +4,7 @@ import {
 	has_retain_columns,
 	increment_path,
 	path_from_depth,
-} from "../utils.js";
+} from '../utils.js'
 
 /**
  * @template T - Model
@@ -15,22 +15,22 @@ import {
  * @returns {Promise<import('$types/create.d.ts').createChildResult<T, A>>}
  */
 export default async function ({ node, data, retain, ...args }) {
-	const ctx = Prisma.getExtensionContext(this);
+	const ctx = Prisma.getExtensionContext(this)
 
 	/** @type {string} */
-	let path = node?.path;
+	let path = node?.path
 	/** @type {number} */
-	let depth = node?.path;
+	let depth = node?.path
 
 	// Get required arguments from instance
 	if (has_nullish(path, depth)) {
 		const target = await ctx.findUniqueOrThrow({
 			where: node,
 			select: { path: true, depth: true },
-		});
+		})
 		if (target) {
-			path = target.path;
-			depth = target.depth;
+			path = target.path
+			depth = target.depth
 		}
 	}
 
@@ -42,22 +42,22 @@ export default async function ({ node, data, retain, ...args }) {
 				depth: true,
 			},
 			orderBy: {
-				path: "desc",
+				path: 'desc',
 			},
 			take: 1,
 		})
-		.then(([s]) => s);
+		.then(([s]) => s)
 
-	const parent_path = path_from_depth({ path, depth: depth - 1 });
+	const parent_path = path_from_depth({ path, depth: depth - 1 })
 
 	// create next path
-	const new_path = increment_path(last_sibling.path);
+	const new_path = increment_path(last_sibling.path)
 
 	let update_data = {
 		numchild: {
 			increment: 1,
 		},
-	};
+	}
 
 	if (has_retain_columns(retain)) {
 		// get parent's old data
@@ -66,9 +66,9 @@ export default async function ({ node, data, retain, ...args }) {
 				path: parent_path,
 			},
 			select: retain,
-		});
+		})
 
-		if (old_data !== null) update_data = { ...update_data, ...old_data };
+		if (old_data !== null) update_data = { ...update_data, ...old_data }
 	}
 
 	const [newborn] = await ctx.__$transaction([
@@ -88,7 +88,7 @@ export default async function ({ node, data, retain, ...args }) {
 			},
 			data: update_data,
 		}),
-	]);
+	])
 
-	return newborn;
+	return newborn
 }

--- a/packages/prisma-extension-bark/src/create/create-sibling.js
+++ b/packages/prisma-extension-bark/src/create/create-sibling.js
@@ -1,5 +1,10 @@
 import { Prisma } from '@prisma/client/extension'
-import { has_nullish, increment_path, path_from_depth } from '../utils.js'
+import {
+	has_nullish,
+	has_retain_columns,
+	increment_path,
+	path_from_depth,
+} from "../utils.js";
 
 /**
  * @template T - Model
@@ -9,42 +14,62 @@ import { has_nullish, increment_path, path_from_depth } from '../utils.js'
  * @param {import('$types/create.d.ts').createSiblingArgs<T, A>} args
  * @returns {Promise<import('$types/create.d.ts').createChildResult<T, A>>}
  */
-export default async function ({ node, data, ...args }) {
-	const ctx = Prisma.getExtensionContext(this)
+export default async function ({ node, data, retain, ...args }) {
+	const ctx = Prisma.getExtensionContext(this);
 
 	/** @type {string} */
-	let path = node?.path
+	let path = node?.path;
 	/** @type {number} */
-	let depth = node?.path
+	let depth = node?.path;
 
 	// Get required arguments from instance
 	if (has_nullish(path, depth)) {
 		const target = await ctx.findUniqueOrThrow({
 			where: node,
-			select: { path: true, depth: true }
-		})
+			select: { path: true, depth: true },
+		});
 		if (target) {
-			path = target.path
-			depth = target.depth
+			path = target.path;
+			depth = target.depth;
 		}
 	}
 
-	const last_sibling = await ctx.findSiblings({
-		node: { path, depth },
-		select: {
-			path: true,
-			depth: true
-		},
-		orderBy: {
-			path: 'desc'
-		},
-		take: 1
-	}).then(([s]) => s)
+	const last_sibling = await ctx
+		.findSiblings({
+			node: { path, depth },
+			select: {
+				path: true,
+				depth: true,
+			},
+			orderBy: {
+				path: "desc",
+			},
+			take: 1,
+		})
+		.then(([s]) => s);
 
-	const parent_path = path_from_depth({ path, depth: depth - 1 })
+	const parent_path = path_from_depth({ path, depth: depth - 1 });
 
 	// create next path
-	const new_path = increment_path(last_sibling.path)
+	const new_path = increment_path(last_sibling.path);
+
+	let update_data = {
+		numchild: {
+			increment: 1,
+		},
+	};
+
+	if (has_retain_columns(retain)) {
+		// get parent's old data
+		const old_data = await ctx.findFirst({
+			where: {
+				path: parent_path,
+			},
+			select: retain,
+		});
+
+		if (old_data !== null) update_data = { ...update_data, ...old_data };
+	}
 
 	const [newborn] = await ctx.__$transaction([
 		ctx.create({
@@ -52,22 +77,18 @@ export default async function ({ node, data, ...args }) {
 				...data,
 				path: new_path,
 				depth: last_sibling.depth,
-				numchild: 0
+				numchild: 0,
 			},
-			...args
+			...args,
 		}),
 		// update parent numchild
 		ctx.update({
 			where: {
-				path: parent_path
+				path: parent_path,
 			},
-			data: {
-				numchild: {
-					increment: 1
-				}
-			}
-		})
-	])
+			data: update_data,
+		}),
+	]);
 
-	return newborn
+	return newborn;
 }

--- a/packages/prisma-extension-bark/src/utils.js
+++ b/packages/prisma-extension-bark/src/utils.js
@@ -70,7 +70,7 @@ export const has_nullish = (...args) => {
  * @returns {boolean}
  */
 export const has_retain_columns = (retain) => {
-  return retain && typeof retain === 'object' && !Array.isArray(retain) && Object.keys(retain).length !== 0
+	return retain && typeof retain === 'object' && !Array.isArray(retain) && Object.keys(retain).length !== 0
 }
 
 export const merge_where_args = (internal, external) => {

--- a/packages/prisma-extension-bark/src/utils.js
+++ b/packages/prisma-extension-bark/src/utils.js
@@ -64,6 +64,15 @@ export const has_nullish = (...args) => {
 	return args.some(a => a ?? true)
 }
 
+/**
+ * 
+ * @param {any} retain 
+ * @returns {boolean}
+ */
+export const has_retain_columns = (retain) => {
+  return retain && typeof retain === 'object' && !Array.isArray(retain) && Object.keys(retain).length !== 0
+}
+
 export const merge_where_args = (internal, external) => {
 	return {
 		...internal,

--- a/packages/prisma-extension-bark/test/create.test.js
+++ b/packages/prisma-extension-bark/test/create.test.js
@@ -21,6 +21,17 @@ describe('createRoot()', async () => {
 })
 
 describe('createChild()', async () => {
+  it('retains field data', async () => {
+    const node = await get_a_node()
+   
+    await prisma.node.createChild({ node: { id: node.id }, retain: { updatedAt: true} })
+
+    const new_node = await get_a_node();
+    
+    // updatedAt value does not change
+    expect(new_node).toStrictEqual({...node, numchild: node.numchild + 1, updatedAt: node.updatedAt})
+  })
+  
 	it('first born', async () => {
 		const node = await get_a_a_node()
 
@@ -30,7 +41,7 @@ describe('createChild()', async () => {
 		expect(result).toStrictEqual({ depth: node.depth + 1, numchild: 0, path: '00010001000100010001' })
 		// New parent
 		const new_node = await get_a_a_node()
-		expect(new_node).toStrictEqual({...node, numchild: node.numchild + 1 })
+		expect(new_node).toStrictEqual({...node, numchild: node.numchild + 1, updatedAt: new_node.updatedAt })
 	})
 
 	it('had kids before', async () => {
@@ -42,8 +53,8 @@ describe('createChild()', async () => {
 		expect(result).toStrictEqual({ depth: node.depth + 1, numchild: 0, path: '0001000100010006' })
 		// Parent
 		const new_node = await get_a_node()
-		expect(new_node).toStrictEqual({ ...node, numchild: node.numchild + 1 })
-	})
+		expect(new_node).toStrictEqual({ ...node, numchild: node.numchild + 1, updatedAt: new_node.updatedAt })
+  })
 
 	afterEach(seedOrResetDB)
 })
@@ -59,7 +70,7 @@ describe('createSibling()', async () => {
 		expect(result).toStrictEqual({ depth: node.depth, numchild: 0, path: '0001000100010006' })
 		// Updated parent
 		const parent_node_after = await get_a_node()
-		expect(parent_node_after).toStrictEqual({ ...parent_node_before, numchild: parent_node_before.numchild + 1 })
+		expect(parent_node_after).toStrictEqual({ ...parent_node_before, numchild: parent_node_before.numchild + 1, updatedAt: parent_node_after.updatedAt })
 	})
 
 	it('w/ node query', async () => {
@@ -72,8 +83,19 @@ describe('createSibling()', async () => {
 		expect(result.path).toBe('0001000100010006')
 		// Updated parent
 		const parent_node_after = await get_a_node()
-		expect(parent_node_after).toStrictEqual({ ...parent_node_before, numchild: parent_node_before.numchild + 1 })
-	})
+		expect(parent_node_after).toStrictEqual({ ...parent_node_before, numchild: parent_node_before.numchild + 1, updatedAt: parent_node_after.updatedAt })
+  })
+  
+  it('retains parent field data', async () => {
+    const node = await get_a_a_node()
+    const parent_node_before = await get_a_node();
+    
+    await prisma.node.createSibling({ node: { id: node.id }, retain: { updatedAt: true } })
+    const parent_node_after = await get_a_node();
+
+    // updatedAt value does not change
+    expect(parent_node_after).toStrictEqual({...parent_node_before, numchild: parent_node_before.numchild + 1, updatedAt: parent_node_before.updatedAt})
+  })
 
 	afterEach(seedOrResetDB)
 })

--- a/packages/prisma-extension-bark/test/create.test.js
+++ b/packages/prisma-extension-bark/test/create.test.js
@@ -21,16 +21,16 @@ describe('createRoot()', async () => {
 })
 
 describe('createChild()', async () => {
-  it('retains field data', async () => {
-    const node = await get_a_node()
+	it('retains field data', async () => {
+		const node = await get_a_node()
    
-    await prisma.node.createChild({ node: { id: node.id }, retain: { updatedAt: true} })
+		await prisma.node.createChild({ node: { id: node.id }, retain: { updatedAt: true} })
 
-    const new_node = await get_a_node();
+		const new_node = await get_a_node()
     
-    // updatedAt value does not change
-    expect(new_node).toStrictEqual({...node, numchild: node.numchild + 1, updatedAt: node.updatedAt})
-  })
+		// updatedAt value does not change
+		expect(new_node).toStrictEqual({...node, numchild: node.numchild + 1, updatedAt: node.updatedAt})
+	})
   
 	it('first born', async () => {
 		const node = await get_a_a_node()
@@ -54,7 +54,7 @@ describe('createChild()', async () => {
 		// Parent
 		const new_node = await get_a_node()
 		expect(new_node).toStrictEqual({ ...node, numchild: node.numchild + 1, updatedAt: new_node.updatedAt })
-  })
+	})
 
 	afterEach(seedOrResetDB)
 })
@@ -84,18 +84,18 @@ describe('createSibling()', async () => {
 		// Updated parent
 		const parent_node_after = await get_a_node()
 		expect(parent_node_after).toStrictEqual({ ...parent_node_before, numchild: parent_node_before.numchild + 1, updatedAt: parent_node_after.updatedAt })
-  })
+	})
   
-  it('retains parent field data', async () => {
-    const node = await get_a_a_node()
-    const parent_node_before = await get_a_node();
+	it('retains parent field data', async () => {
+		const node = await get_a_a_node()
+		const parent_node_before = await get_a_node()
     
-    await prisma.node.createSibling({ node: { id: node.id }, retain: { updatedAt: true } })
-    const parent_node_after = await get_a_node();
+		await prisma.node.createSibling({ node: { id: node.id }, retain: { updatedAt: true } })
+		const parent_node_after = await get_a_node()
 
-    // updatedAt value does not change
-    expect(parent_node_after).toStrictEqual({...parent_node_before, numchild: parent_node_before.numchild + 1, updatedAt: parent_node_before.updatedAt})
-  })
+		// updatedAt value does not change
+		expect(parent_node_after).toStrictEqual({...parent_node_before, numchild: parent_node_before.numchild + 1, updatedAt: parent_node_before.updatedAt})
+	})
 
 	afterEach(seedOrResetDB)
 })

--- a/packages/prisma-extension-bark/test/setup/schema.prisma
+++ b/packages/prisma-extension-bark/test/setup/schema.prisma
@@ -15,7 +15,8 @@ model node {
     numchild Int     @default(0)
     // Not required but makes it easier to test
     name     String?
-
+    createdAt DateTime @default(now())
+    updatedAt DateTime @updatedAt
     @@index([path])
 }
 

--- a/packages/prisma-extension-bark/types/create.d.ts
+++ b/packages/prisma-extension-bark/types/create.d.ts
@@ -1,36 +1,42 @@
-import type { Rename, XOR } from "./helpers.d.ts";
+import type { OmitKeys, Rename, XOR } from "./helpers.d.ts";
 import {
-	PrismaModelFunctionArgs as PMFArgs,
-	PrismaModelProps as PMP,
-	RequirePrismaModelTypeInput as RequirePMTInput,
-	RequiredKeysInInputNode
+  PrismaModelFunctionArgs as PMFArgs,
+  PrismaModelProps as PMP,
+  RequirePrismaModelTypeInput as RequirePMTInput,
+  RequiredKeysInInputNode,
+  RetainableKeys
 } from "./prisma";
 
 import type { Prisma } from '@prisma/client'
 
-
 // createSibling
 export type createSiblingArgs<T, A> = XOR<
-	{ node: RequiredKeysInInputNode<T, A, 'depth' | 'path'>; },
-	Rename<Pick<Prisma.Args<T, 'findUniqueOrThrow'>, 'where'>, 'where', 'node'>
+  { node: RequiredKeysInInputNode<T, A, 'depth' | 'path'>; },
+  Rename<Pick<Prisma.Args<T, 'findUniqueOrThrow'>, 'where'>, 'where', 'node'>
 > & {
-	data?: Omit<Prisma.Args<T, 'create'>['data'], 'path' | 'depth' | 'numchild'>
-} & Omit<Prisma.Args<T, 'create'>, 'data'>;
+  data?: Omit<Prisma.Args<T, 'create'>['data'], 'path' | 'depth' | 'numchild'>
+} & Omit<Prisma.Args<T, 'create'>, 'data'
+> & {
+  retain?: RetainableKeys<Prisma.Args<T, "create">['data'], "path" | "id" | "depth" | "numchild">
+};
 export type createSiblingResult<T, A> = Prisma.Result<T, A, 'create'>;
 
 
 // createChild
 export type createChildArgs<T, A> = XOR<
-	{ node: RequiredKeysInInputNode<T, A, 'depth' | 'path' | 'numchild'>; },
-	Rename<Pick<Prisma.Args<T, 'findUniqueOrThrow'>, 'where'>, 'where', 'node'>
+  { node: RequiredKeysInInputNode<T, A, 'depth' | 'path' | 'numchild'>; },
+  Rename<Pick<Prisma.Args<T, 'findUniqueOrThrow'>, 'where'>, 'where', 'node'>
 > & {
-	data?: Omit<Prisma.Args<T, 'create'>['data'], 'path' | 'depth' | 'numchild'>
-} & Omit<Prisma.Args<T, 'create'>, 'data'>;
+  data?: Omit<Prisma.Args<T, 'create'>['data'], 'path' | 'depth' | 'numchild'>
+} & Omit<Prisma.Args<T, 'create'>, 'data'
+> & {
+  retain?: RetainableKeys<Prisma.Args<T, "create">['data'], "path" | "id" | "depth" | "numchild">
+};
 export type createChildResult<T, A> = Prisma.Result<T, A, 'create'>;
 
 
 // createRoot
 export type createRootArgs<T, A> = {
-	data?: Omit<Prisma.Args<T, 'create'>['data'], 'path' | 'depth' | 'numchild'>
+  data?: Omit<Prisma.Args<T, 'create'>['data'], 'path' | 'depth' | 'numchild'>
 } & Omit<Prisma.Args<T, 'create'>, 'data'>;
 export type createRootResult<T, A> = Prisma.Result<T, A, 'create'>;

--- a/packages/prisma-extension-bark/types/helpers.d.ts
+++ b/packages/prisma-extension-bark/types/helpers.d.ts
@@ -2,9 +2,11 @@ type Without<T, U> = { [P in Exclude<keyof T, keyof U>]?: never };
 export type XOR<T, U> = (T | U) extends object ? (Without<T, U> & U) | (Without<U, T> & T) : T | U;
 
 export type ObjectFromList<T extends ReadonlyArray<string>, P extends any> = {
-	readonly [K in (T extends ReadonlyArray<infer U> ? U : never)]: P
+  readonly [K in (T extends ReadonlyArray<infer U> ? U : never)]: P
 };
 
 export type RequireKeys<T, K> = Partial<T> & Required<Pick<T, K>>;
+
+export type RetainKeys<T> = { [R in keyof T]?: true }
 
 export type Rename<T, K extends keyof T, N extends string> = Pick<T, Exclude<keyof T, K>> & { [P in N]: T[K] }

--- a/packages/prisma-extension-bark/types/prisma.d.ts
+++ b/packages/prisma-extension-bark/types/prisma.d.ts
@@ -1,5 +1,5 @@
 import { Prisma, PrismaClient } from "@prisma/client"
-import { RequireKeys } from "./helpers.d.ts";
+import { RequireKeys, RetainKeys } from "./helpers.d.ts";
 
 /**
  * Model methods available in Prisma. (e.g. `prisma.node` or `prisma.user`)
@@ -35,3 +35,5 @@ export type RequirePrismaModelTypeInput<TModelName extends PrismaModelProps, RKe
 export type PrismaModelBuiltinFunctionKeys<TModelName extends PrismaModelProps> = keyof PrismaModelTypeMap<TModelName>[TModelName]['operations']
 
 export type RequiredKeysInInputNode<T, A, K> = RequireKeys<Prisma.Result<T, A, 'findFirst'>, K>
+
+export type RetainableKeys<T, K extends keyof T> =  RetainKeys<Omit<T, K>> 


### PR DESCRIPTION
This provides a workaround to prevent updating the data for certain columns that auto-update whenever `.update()` prisma method is called.

In my case, it was to prevent columns with an @updatedAt field attribute from updating whenever I call the `.createSibling` and `.createChild` methods ( _which calls the .update() internally_ ) .

### Usage: 

> It is structured like a select field where you explicitly include fields you want to retain. If undefined, all auto-updating fields will update as per usual

> ` await prisma.model.createChild({ where: {}, data: {}, retain: { columnYouDontWantUpdating: true } `

It basically fetches the old values of specified retain columns and inserts it back with the new numchild number - which is the current implementation of the extension create methods.

### Reasons for implementing:
I have a model  with comments that can have their own comments ( _replies_ ) and the date is shown on my app to reflect when they were last edited by their respective authors. With the tweaked implementation, having replies won't update the date of the comment. If I do want the date to update, say the author edits the comment message, I can simply omit the retain field.
           