### PR TITLE
bark still works when setting a custom path for prisma generate

### DIFF
--- a/.changeset/custom-prisma-path.md
+++ b/.changeset/custom-prisma-path.md
@@ -1,0 +1,16 @@
+---
+"prisma-extension-bark": minor
+---
+
+Add support for custom Prisma client paths
+
+Users can now specify a custom Prisma client path when initializing Bark, which is useful when the Prisma client is generated to a custom location:
+
+```js
+const xprisma = new PrismaClient().$extends(
+  await withBark({ 
+    modelNames: ['node'],
+    prismaClientPath: '../generated/prisma-client/extension'
+  })()
+)
+```

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ node_modules
 !.env.example
 /**/test/setup/migrations
 /**/test/setup/test.db
+dist
+packages/*/dist

--- a/packages/prisma-extension-bark/README.md
+++ b/packages/prisma-extension-bark/README.md
@@ -46,8 +46,33 @@ npx prisma migrate dev
 import { PrismaClient } from '@prisma/client'
 import { withBark } from 'prisma-extension-bark'
 
-const xprisma = new PrismaClient().$extends(withBark({ modelNames: ['node'] }))
+const xprisma = new PrismaClient().$extends(await withBark({ modelNames: ['node'] })())
 
 const myNewRootNode = await xprisma.node.createRoot({ data: { name: 'My new root' } })
 // { id: 1, path: '0001', depth: 1, numchild: 0, name: 'My new root' }
+```
+
+### Using Custom Prisma Client Path
+
+If you've configured a custom output path for your Prisma Client in `schema.prisma`:
+
+```prisma
+generator client {
+  provider = "prisma-client-js"
+  output   = "../generated/prisma-client"
+}
+```
+
+You need to specify the path when initializing Bark:
+
+```js
+import { PrismaClient } from '../generated/prisma-client'
+import { withBark } from 'prisma-extension-bark'
+
+const xprisma = new PrismaClient().$extends(
+  await withBark({ 
+    modelNames: ['node'],
+    prismaClientPath: '../generated/prisma-client/extension'
+  })()
+)
 ```

--- a/packages/prisma-extension-bark/package.json
+++ b/packages/prisma-extension-bark/package.json
@@ -4,12 +4,12 @@
     "description": "A materialized path extension for Prisma",
     "license": "MIT",
     "bugs": {
-        "url": "https://github.com/adamjkb/bark/issues"
+        "url": "https://github.com/lpan/bark/issues"
     },
     "homepage": "https://prisma-extension-bark.gitbook.io/",
     "repository": {
         "type": "git",
-        "url": "https://github.com/adamjkb/bark",
+        "url": "https://github.com/lpan/bark",
         "directory": "packages/prisma-extension-bark"
     },
     "author": {
@@ -41,6 +41,7 @@
     },
     "scripts": {
         "build": "esbuild ./src/index.js --bundle --format=cjs --outfile=dist/index.cjs --platform=node --external:@prisma/client",
+        "prepare": "pnpm build",
         "prepublishOnly": "pnpm build",
         "test": "vitest",
         "prisma:generate": "pnpx prisma generate --schema=./test/setup/schema.prisma",

--- a/packages/prisma-extension-bark/package.json
+++ b/packages/prisma-extension-bark/package.json
@@ -35,7 +35,8 @@
         ".": {
             "types": "./types/index.d.ts",
             "import": "./src/index.js",
-            "require": "./dist/index.cjs"
+            "require": "./dist/index.cjs",
+            "default": "./src/index.js"
         },
         "./package.json": "./package.json"
     },

--- a/packages/prisma-extension-bark/src/create/create-child.js
+++ b/packages/prisma-extension-bark/src/create/create-child.js
@@ -1,4 +1,4 @@
-import { Prisma } from '@prisma/client/extension'
+import { getPrisma } from '../get-prisma.js'
 import { has_nullish, int2str } from '../utils.js'
 
 /**
@@ -10,6 +10,7 @@ import { has_nullish, int2str } from '../utils.js'
  * @returns {Promise<import('$types/create.d.ts').createChildResult<T, A>>}
  */
 export default async function ({ node, data, ...args }) {
+	const Prisma = await getPrisma(this)
 	const ctx = Prisma.getExtensionContext(this)
 
 	/** @type {string} */

--- a/packages/prisma-extension-bark/src/create/create-root.js
+++ b/packages/prisma-extension-bark/src/create/create-root.js
@@ -1,4 +1,4 @@
-import { Prisma } from '@prisma/client/extension'
+import { getPrisma } from '../get-prisma.js'
 import { increment_path, int2str } from '../utils.js'
 
 /**
@@ -10,6 +10,7 @@ import { increment_path, int2str } from '../utils.js'
  * @returns {Promise<import('$types/create.d.ts').createRootResult<T, A>>}
  */
 export default async function ({ data, ...args }) {
+	const Prisma = await getPrisma(this)
 	const ctx = Prisma.getExtensionContext(this)
 
 	const last_root = await ctx.findLastRoot({ select: {

--- a/packages/prisma-extension-bark/src/create/create-sibling.js
+++ b/packages/prisma-extension-bark/src/create/create-sibling.js
@@ -1,4 +1,4 @@
-import { Prisma } from '@prisma/client/extension'
+import { getPrisma } from '../get-prisma.js'
 import { has_nullish, increment_path, path_from_depth } from '../utils.js'
 
 /**
@@ -10,6 +10,7 @@ import { has_nullish, increment_path, path_from_depth } from '../utils.js'
  * @returns {Promise<import('$types/create.d.ts').createChildResult<T, A>>}
  */
 export default async function ({ node, data, ...args }) {
+	const Prisma = await getPrisma(this)
 	const ctx = Prisma.getExtensionContext(this)
 
 	/** @type {string} */

--- a/packages/prisma-extension-bark/src/delete/delete-many-nodes.js
+++ b/packages/prisma-extension-bark/src/delete/delete-many-nodes.js
@@ -1,4 +1,4 @@
-import { Prisma } from '@prisma/client/extension'
+import { getPrisma } from '../get-prisma.js'
 import { path_from_depth } from '../utils.js'
 import { STEP_LENGTH } from '../consts.js'
 
@@ -11,6 +11,7 @@ import { STEP_LENGTH } from '../consts.js'
  * @returns {Promise<import('$types/delete.d.ts').deleteManyNodesResult<T, A>>}
  */
 export default async function ({ where }) {
+	const Prisma = await getPrisma(this)
 	const ctx = Prisma.getExtensionContext(this)
 
 	const targets = await ctx.findMany({

--- a/packages/prisma-extension-bark/src/delete/delete-node.js
+++ b/packages/prisma-extension-bark/src/delete/delete-node.js
@@ -1,4 +1,4 @@
-import { Prisma } from '@prisma/client/extension'
+import { getPrisma } from '../get-prisma.js'
 import { has_nullish, path_from_depth } from '../utils.js'
 
 /**
@@ -10,6 +10,7 @@ import { has_nullish, path_from_depth } from '../utils.js'
  * @returns {Promise<import('$types/delete.d.ts').deleteNodeResult<T, A>>}
  */
 export default async function ({ node }) {
+	const Prisma = await getPrisma(this)
 	const ctx = Prisma.getExtensionContext(this)
 
 	/** @type {string} */

--- a/packages/prisma-extension-bark/src/find/find-ancestors.js
+++ b/packages/prisma-extension-bark/src/find/find-ancestors.js
@@ -1,4 +1,4 @@
-import { Prisma } from '@prisma/client/extension'
+import { getPrisma } from '../get-prisma.js'
 import { default_order_by } from '../consts.js'
 import { has_nullish, merge_where_args } from '../utils.js'
 
@@ -11,6 +11,7 @@ import { has_nullish, merge_where_args } from '../utils.js'
  * @returns {Promise<import('$types/find.d.ts').findAncestorsResult<T, A>>}
  */
 export default async function ({ node, where, orderBy = default_order_by, ...args }) {
+	const Prisma = await getPrisma(this)
 	const ctx = Prisma.getExtensionContext(this)
 
 	/** @type {string} */

--- a/packages/prisma-extension-bark/src/find/find-children.js
+++ b/packages/prisma-extension-bark/src/find/find-children.js
@@ -1,4 +1,4 @@
-import { Prisma } from '@prisma/client/extension'
+import { getPrisma } from '../get-prisma.js'
 import { default_order_by, max_segment, min_segment } from '../consts.js'
 import { has_nullish, merge_where_args } from '../utils.js'
 
@@ -11,6 +11,7 @@ import { has_nullish, merge_where_args } from '../utils.js'
  * @returns {Promise<import('$types/find.d.ts').findChildrenResult<T, A>>}
  */
 export default async function ({ node, orderBy = default_order_by, where, ...args }) {
+	const Prisma = await getPrisma(this)
 	const ctx = Prisma.getExtensionContext(this)
 
 	/** @type {string} */

--- a/packages/prisma-extension-bark/src/find/find-descendants.js
+++ b/packages/prisma-extension-bark/src/find/find-descendants.js
@@ -1,4 +1,4 @@
-import { Prisma } from '@prisma/client/extension'
+import { getPrisma } from '../get-prisma.js'
 import { default_order_by } from '../consts.js'
 import { has_nullish, merge_where_args } from '../utils.js'
 
@@ -11,6 +11,7 @@ import { has_nullish, merge_where_args } from '../utils.js'
  * @returns {Promise<import('$types/find.d.ts').findDescendantsResult<T, A>>}
  */
 export default async function ({ node, where, orderBy = default_order_by, ...args }) {
+	const Prisma = await getPrisma(this)
 	const ctx = Prisma.getExtensionContext(this)
 
 	/** @type {string} */

--- a/packages/prisma-extension-bark/src/find/find-last-root.js
+++ b/packages/prisma-extension-bark/src/find/find-last-root.js
@@ -1,4 +1,4 @@
-import { Prisma } from '@prisma/client/extension'
+import { getPrisma } from '../get-prisma.js'
 import { merge_where_args } from '../utils.js'
 
 
@@ -11,6 +11,7 @@ import { merge_where_args } from '../utils.js'
  * @returns {Promise<import('$types/find.d.ts').findLastRootNodeResult<T, A>>}
  */
 export default async function (args) {
+	const Prisma = await getPrisma(this)
 	const ctx = Prisma.getExtensionContext(this)
 
 	return ctx.findFirst({

--- a/packages/prisma-extension-bark/src/find/find-parent.js
+++ b/packages/prisma-extension-bark/src/find/find-parent.js
@@ -1,4 +1,4 @@
-import { Prisma } from '@prisma/client/extension'
+import { getPrisma } from '../get-prisma.js'
 import { has_nullish, merge_where_args, path_from_depth } from '../utils.js'
 
 /**
@@ -10,6 +10,7 @@ import { has_nullish, merge_where_args, path_from_depth } from '../utils.js'
  * @returns {Promise<import('$types/find.d.ts').findParentResult<T, A>>}
  */
 export default async function ({ node, where, ...args }) {
+	const Prisma = await getPrisma(this)
 	const ctx = Prisma.getExtensionContext(this)
 
 	/** @type {string} */

--- a/packages/prisma-extension-bark/src/find/find-siblings.js
+++ b/packages/prisma-extension-bark/src/find/find-siblings.js
@@ -1,4 +1,4 @@
-import { Prisma } from '@prisma/client/extension'
+import { getPrisma } from '../get-prisma.js'
 import { default_order_by, max_segment, min_segment } from '../consts.js'
 import { has_nullish, merge_where_args, path_from_depth } from '../utils.js'
 
@@ -11,6 +11,7 @@ import { has_nullish, merge_where_args, path_from_depth } from '../utils.js'
  * @returns {Promise<import('$types/find.d.ts').findSiblingsResult<T, A>>}
  */
 export default async function ({ node, where, orderBy = default_order_by, ...args }) {
+	const Prisma = await getPrisma(this)
 	const ctx = Prisma.getExtensionContext(this)
 
 	/** @type {string} */

--- a/packages/prisma-extension-bark/src/get-prisma.js
+++ b/packages/prisma-extension-bark/src/get-prisma.js
@@ -1,0 +1,12 @@
+const prismaCache = new Map()
+
+export async function getPrisma(context) {
+	const path = context?._prismaClientPath || '@prisma/client/extension'
+	
+	if (!prismaCache.has(path)) {
+		const module = await import(path)
+		prismaCache.set(path, module.Prisma)
+	}
+	
+	return prismaCache.get(path)
+}

--- a/packages/prisma-extension-bark/src/index.js
+++ b/packages/prisma-extension-bark/src/index.js
@@ -1,5 +1,3 @@
-import { Prisma } from '@prisma/client/extension'
-
 import * as find from './find/index.js'
 import * as create from './create/index.js'
 import * as deletes from './delete/index.js'
@@ -10,18 +8,41 @@ import * as operations from './operations/index.js'
 *
 * @type {import('$types/index.d.ts').withBark}
 */
-export const withBark = (args) => Prisma.defineExtension(function (client) {
-	const extensionMethods = {
-		...find,
-		...create,
-		...deletes,
-		...operations,
-		/** Note: internal use only */
-		__$transaction: async (...args)  => client.$transaction(...args)
+export const withBark = (args) => {
+	const prismaPath = args.prismaClientPath || '@prisma/client/extension'
+	
+	// Inject prismaClientPath into all methods
+	const injectPath = (methods) => {
+		return Object.fromEntries(
+			Object.entries(methods).map(([key, fn]) => [
+				key,
+				function(...fnArgs) {
+					// Add prismaClientPath to context
+					this._prismaClientPath = prismaPath
+					return fn.apply(this, fnArgs)
+				}
+			])
+		)
 	}
+	
+	return async function(client) {
+		const { Prisma } = await import(prismaPath)
+		
+		return Prisma.defineExtension(function (client) {
+			const extensionMethods = {
+				...injectPath(find),
+				...injectPath(create),
+				...injectPath(deletes),
+				...injectPath(operations),
+				/** Note: internal use only */
+				__$transaction: async (...args)  => client.$transaction(...args),
+				_prismaClientPath: prismaPath
+			}
 
-	return client.$extends({
-		name: 'prisma-extension-bark',
-		model: Object.fromEntries(args.modelNames.map(m => [m, extensionMethods])),
-	})
-})
+			return client.$extends({
+				name: 'prisma-extension-bark',
+				model: Object.fromEntries(args.modelNames.map(m => [m, extensionMethods])),
+			})
+		})
+	}
+}

--- a/packages/prisma-extension-bark/src/operations/move.js
+++ b/packages/prisma-extension-bark/src/operations/move.js
@@ -1,4 +1,4 @@
-import { Prisma } from '@prisma/client/extension'
+import { getPrisma } from '../get-prisma.js'
 import { has_nullish, increment_path, int2str, last_position_in_path, path_from_depth } from '../utils.js'
 
 /**
@@ -10,6 +10,7 @@ import { has_nullish, increment_path, int2str, last_position_in_path, path_from_
  * @returns {Promise<import('$types/operations.d.ts').moveResult>}
  */
 export default async function ({ node, position, referenceNode }) {
+	const Prisma = await getPrisma(this)
 	const ctx = Prisma.getExtensionContext(this)
 
 	let original_node = node

--- a/packages/prisma-extension-bark/types/create.d.ts
+++ b/packages/prisma-extension-bark/types/create.d.ts
@@ -1,4 +1,4 @@
-import type { Rename, XOR } from "./helpers.d.ts";
+import type { Rename, XOR } from "./helpers";
 import {
 	PrismaModelFunctionArgs as PMFArgs,
 	PrismaModelProps as PMP,

--- a/packages/prisma-extension-bark/types/delete.d.ts
+++ b/packages/prisma-extension-bark/types/delete.d.ts
@@ -1,6 +1,6 @@
-import { Rename, XOR } from "./helpers.d.ts";
+import { Rename, XOR } from "./helpers";
 import type { Prisma } from '@prisma/client'
-import { RequiredKeysInInputNode } from "./prisma.d.ts";
+import { RequiredKeysInInputNode } from "./prisma";
 
 
 // deleteNode

--- a/packages/prisma-extension-bark/types/find.d.ts
+++ b/packages/prisma-extension-bark/types/find.d.ts
@@ -1,5 +1,5 @@
-import type { Rename, XOR } from "./helpers.d.ts";
-import { RequiredKeysInInputNode } from "./prisma.d.ts";
+import type { Rename, XOR } from "./helpers";
+import { RequiredKeysInInputNode } from "./prisma";
 
 import type { Prisma } from '@prisma/client'
 

--- a/packages/prisma-extension-bark/types/index.d.ts
+++ b/packages/prisma-extension-bark/types/index.d.ts
@@ -13,6 +13,13 @@ type BarkInitArgs = {
 	 * Minimum required model: {@link https://prisma-extension-bark.gitbook.io/docs/model-reference#minimum-required-model}
 	 */
 	modelNames: PrismaModelProps[];
+	/**
+	 * Optional custom path to the Prisma client
+	 * 
+	 * @default '@prisma/client/extension'
+	 * @example '../generated/prisma-client/extension'
+	 */
+	prismaClientPath?: string;
 }
 
 export type BarkFindMethods = {
@@ -50,7 +57,14 @@ export type BarkMethods = BarkFindMethods & BarkCreateMethods & BarkDeleteMethod
  * const xprisma = new PrismaClient().$extends(withBark({
  *  modelNames: ['node']
  * }))
+ * 
+ * @example
+ * // With custom Prisma client path
+ * const xprisma = new PrismaClient().$extends(withBark({
+ *  modelNames: ['node'],
+ *  prismaClientPath: '../generated/prisma-client/extension'
+ * }))
  */
-export declare function withBark<I extends BarkInitArgs>(args: I): (client: any) => PrismaDefault.PrismaClientExtends<Types.Extensions.InternalArgs<{}, {
+export declare function withBark<I extends BarkInitArgs>(args: I): (client: any) => Promise<PrismaDefault.PrismaClientExtends<Types.Extensions.InternalArgs<{}, {
 	readonly [K in (I['modelNames'] extends ReadonlyArray<infer U> ? U : never)]: BarkMethods
-}, {}, {}> & Types.Extensions.InternalArgs<{}, {}, {}, {}> & Types.Extensions.DefaultArgs>;
+}, {}, {}> & Types.Extensions.InternalArgs<{}, {}, {}, {}> & Types.Extensions.DefaultArgs>>;

--- a/packages/prisma-extension-bark/types/index.d.ts
+++ b/packages/prisma-extension-bark/types/index.d.ts
@@ -1,10 +1,10 @@
-import PrismaDefault, { type Prisma } from "@prisma/client/scripts/default-index.d.ts";
-import type { Types } from "@prisma/client/runtime/library.d.ts";
-import { PrismaModelProps } from "./prisma.d.ts";
-import { findAncestorsArgs, findChildrenArgs, findChildrenResult, findDescendantsArgs, findDescendantsResult, findLastRootNodeArgs, findLastRootNodeResult, findParentArgs, findParentResult, findSiblingsArgs, findSiblingsResult } from "./find.d.ts";
-import { createChildArgs, createRootArgs, createSiblingArgs, createSiblingResult } from "./create.d.ts";
-import { deleteManyNodesArgs, deleteManyNodesResult, deleteNodeArgs, deleteNodeResult } from "./delete.d.ts";
-import { moveArgs, moveResult } from "./operations.d.ts";
+import PrismaDefault, { type Prisma } from "@prisma/client/scripts/default-index";
+import type { Types } from "@prisma/client/runtime/library";
+import { PrismaModelProps } from "./prisma";
+import { findAncestorsArgs, findChildrenArgs, findChildrenResult, findDescendantsArgs, findDescendantsResult, findLastRootNodeArgs, findLastRootNodeResult, findParentArgs, findParentResult, findSiblingsArgs, findSiblingsResult } from "./find";
+import { createChildArgs, createRootArgs, createSiblingArgs, createSiblingResult } from "./create";
+import { deleteManyNodesArgs, deleteManyNodesResult, deleteNodeArgs, deleteNodeResult } from "./delete";
+import { moveArgs, moveResult } from "./operations";
 
 type BarkInitArgs = {
 	/**

--- a/packages/prisma-extension-bark/types/operations.d.ts
+++ b/packages/prisma-extension-bark/types/operations.d.ts
@@ -1,6 +1,6 @@
-import type { Rename, XOR } from "./helpers.d.ts";
+import type { Rename, XOR } from "./helpers";
 import type { Prisma } from '@prisma/client'
-import { RequiredKeysInInputNode } from "./prisma.d.ts";
+import { RequiredKeysInInputNode } from "./prisma";
 
 
 // move

--- a/packages/prisma-extension-bark/types/prisma.d.ts
+++ b/packages/prisma-extension-bark/types/prisma.d.ts
@@ -1,5 +1,5 @@
 import { Prisma, PrismaClient } from "@prisma/client"
-import { RequireKeys } from "./helpers.d.ts";
+import { RequireKeys } from "./helpers";
 
 /**
  * Model methods available in Prisma. (e.g. `prisma.node` or `prisma.user`)


### PR DESCRIPTION
## Why
- Currently, bark hardcodes the generated path location. So it will blow up with not found if we set a custom generated file location.
- Fixes https://github.com/adamjkb/bark/issues/87

## What
- I did a quick Claude Code iteration. Looks like it changes the public interface, and probably we need to do a major version bump... I want the maintainer to weight in here