### PR TITLE
Do not depend on runtime Prisma deps

### DIFF
--- a/.changeset/custom-prisma-paths.md
+++ b/.changeset/custom-prisma-paths.md
@@ -1,0 +1,10 @@
+---
+"prisma-extension-bark": minor
+---
+
+Add support for custom Prisma client output paths
+
+- Remove hardcoded @prisma/client imports from internal files
+- Accept Prisma namespace as parameter to support custom client paths
+- Maintain backward compatibility with default @prisma/client imports
+- Add comprehensive tests for custom path configurations

--- a/packages/prisma-extension-bark/README.md
+++ b/packages/prisma-extension-bark/README.md
@@ -43,11 +43,27 @@ npx prisma migrate dev
 ## 4. Extend Prisma Client with Bark
 ```js
 // index.js
-import { PrismaClient } from '@prisma/client'
+import { PrismaClient, Prisma } from '@prisma/client'
 import { withBark } from 'prisma-extension-bark'
 
-const xprisma = new PrismaClient().$extends(withBark({ modelNames: ['node'] }))
+const xprisma = new PrismaClient().$extends(
+  withBark({ modelNames: ['node'] })(Prisma)
+)
 
 const myNewRootNode = await xprisma.node.createRoot({ data: { name: 'My new root' } })
 // { id: 1, path: '0001', depth: 1, numchild: 0, name: 'My new root' }
+```
+
+### Using Custom Prisma Output Paths
+
+If you're using Prisma with a custom output path (common in monorepo setups), you need to pass the Prisma namespace from your generated client:
+
+```js
+// With custom output path
+import { PrismaClient, Prisma } from '../generated/client'
+import { withBark } from 'prisma-extension-bark'
+
+const xprisma = new PrismaClient().$extends(
+  withBark({ modelNames: ['node'] })(Prisma)
+)
 ```

--- a/packages/prisma-extension-bark/README.md
+++ b/packages/prisma-extension-bark/README.md
@@ -17,6 +17,14 @@ npm i -D prisma
 npx prisma init
 ```
 
+#### Installing from GitHub
+
+You can also install directly from GitHub before the changes are published to npm:
+
+```bash
+npm i github:lpan/bark#lpan/custom-prisma-path-take-2 --workspace=packages/prisma-extension-bark
+```
+
 ### 2. Implement the required field on your model
 ```prisma
 // prisma/schema.prisma

--- a/packages/prisma-extension-bark/README.md
+++ b/packages/prisma-extension-bark/README.md
@@ -19,10 +19,33 @@ npx prisma init
 
 #### Installing from GitHub
 
-You can also install directly from GitHub before the changes are published to npm:
+To install directly from GitHub before the changes are published to npm:
 
+**For pnpm users:**
 ```bash
-npm i github:lpan/bark#lpan/custom-prisma-path-take-2 --workspace=packages/prisma-extension-bark
+# Install from the monorepo subdirectory
+pnpm add "github:lpan/bark#path:packages/prisma-extension-bark&lpan/custom-prisma-path-take-2"
+
+# Or use pnpm link for local development
+git clone -b lpan/custom-prisma-path-take-2 https://github.com/lpan/bark.git
+cd bark/packages/prisma-extension-bark
+pnpm install
+pnpm link --global
+
+# Then in your project:
+pnpm link --global prisma-extension-bark
+```
+
+**For npm/yarn users (use local linking):**
+```bash
+# Clone and link locally
+git clone -b lpan/custom-prisma-path-take-2 https://github.com/lpan/bark.git
+cd bark/packages/prisma-extension-bark
+npm install
+npm link
+
+# Then in your project:
+npm link prisma-extension-bark
 ```
 
 ### 2. Implement the required field on your model

--- a/packages/prisma-extension-bark/README.md
+++ b/packages/prisma-extension-bark/README.md
@@ -17,37 +17,6 @@ npm i -D prisma
 npx prisma init
 ```
 
-#### Installing from GitHub
-
-To install directly from GitHub before the changes are published to npm:
-
-**For pnpm users:**
-```bash
-# Install from the monorepo subdirectory
-pnpm add "github:lpan/bark#path:packages/prisma-extension-bark&lpan/custom-prisma-path-take-2"
-
-# Or use pnpm link for local development
-git clone -b lpan/custom-prisma-path-take-2 https://github.com/lpan/bark.git
-cd bark/packages/prisma-extension-bark
-pnpm install
-pnpm link --global
-
-# Then in your project:
-pnpm link --global prisma-extension-bark
-```
-
-**For npm/yarn users (use local linking):**
-```bash
-# Clone and link locally
-git clone -b lpan/custom-prisma-path-take-2 https://github.com/lpan/bark.git
-cd bark/packages/prisma-extension-bark
-npm install
-npm link
-
-# Then in your project:
-npm link prisma-extension-bark
-```
-
 ### 2. Implement the required field on your model
 ```prisma
 // prisma/schema.prisma
@@ -74,27 +43,11 @@ npx prisma migrate dev
 ## 4. Extend Prisma Client with Bark
 ```js
 // index.js
-import { PrismaClient, Prisma } from '@prisma/client'
+import { PrismaClient } from '@prisma/client'
 import { withBark } from 'prisma-extension-bark'
 
-const xprisma = new PrismaClient().$extends(
-  withBark({ modelNames: ['node'] })(Prisma)
-)
+const xprisma = new PrismaClient().$extends(withBark({ modelNames: ['node'] }))
 
 const myNewRootNode = await xprisma.node.createRoot({ data: { name: 'My new root' } })
 // { id: 1, path: '0001', depth: 1, numchild: 0, name: 'My new root' }
-```
-
-### Using Custom Prisma Output Paths
-
-If you're using Prisma with a custom output path (common in monorepo setups), you need to pass the Prisma namespace from your generated client:
-
-```js
-// With custom output path
-import { PrismaClient, Prisma } from '../generated/client'
-import { withBark } from 'prisma-extension-bark'
-
-const xprisma = new PrismaClient().$extends(
-  withBark({ modelNames: ['node'] })(Prisma)
-)
 ```

--- a/packages/prisma-extension-bark/package-lock.json
+++ b/packages/prisma-extension-bark/package-lock.json
@@ -7,12 +7,15 @@
         "": {
             "name": "prisma-extension-bark",
             "version": "1.0.0-next.2",
+            "hasInstallScript": true,
             "license": "MIT",
+            "dependencies": {
+                "esbuild": "^0.20.0"
+            },
             "devDependencies": {
                 "@eslint/compat": "^1.1.1",
                 "@eslint/js": "^9.8.0",
                 "@types/node": "^22.1.0",
-                "esbuild": "^0.20.0",
                 "eslint": "^9.8.0",
                 "globals": "^15.9.0",
                 "prisma": "^5.0.0",
@@ -39,7 +42,6 @@
             "cpu": [
                 "ppc64"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "aix"
@@ -55,7 +57,6 @@
             "cpu": [
                 "arm"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "android"
@@ -71,7 +72,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "android"
@@ -87,7 +87,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "android"
@@ -103,7 +102,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "darwin"
@@ -119,7 +117,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "darwin"
@@ -135,7 +132,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "freebsd"
@@ -151,7 +147,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "freebsd"
@@ -167,7 +162,6 @@
             "cpu": [
                 "arm"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "linux"
@@ -183,7 +177,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "linux"
@@ -199,7 +192,6 @@
             "cpu": [
                 "ia32"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "linux"
@@ -215,7 +207,6 @@
             "cpu": [
                 "loong64"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "linux"
@@ -231,7 +222,6 @@
             "cpu": [
                 "mips64el"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "linux"
@@ -247,7 +237,6 @@
             "cpu": [
                 "ppc64"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "linux"
@@ -263,7 +252,6 @@
             "cpu": [
                 "riscv64"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "linux"
@@ -279,7 +267,6 @@
             "cpu": [
                 "s390x"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "linux"
@@ -295,7 +282,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "linux"
@@ -311,7 +297,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "netbsd"
@@ -327,7 +312,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "openbsd"
@@ -343,7 +327,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "sunos"
@@ -359,7 +342,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "win32"
@@ -375,7 +357,6 @@
             "cpu": [
                 "ia32"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "win32"
@@ -391,7 +372,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "win32"
@@ -1316,7 +1296,6 @@
             "version": "0.20.2",
             "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.2.tgz",
             "integrity": "sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==",
-            "dev": true,
             "hasInstallScript": true,
             "bin": {
                 "esbuild": "bin/esbuild"

--- a/packages/prisma-extension-bark/package-lock.json
+++ b/packages/prisma-extension-bark/package-lock.json
@@ -1,19 +1,23 @@
 {
     "name": "prisma-extension-bark",
-    "version": "0.2.3",
+    "version": "1.0.0-next.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "prisma-extension-bark",
-            "version": "0.2.3",
+            "version": "1.0.0-next.2",
             "license": "MIT",
             "devDependencies": {
+                "@eslint/compat": "^1.1.1",
+                "@eslint/js": "^9.8.0",
+                "@types/node": "^22.1.0",
                 "esbuild": "^0.20.0",
-                "eslint": "^8.45.0",
+                "eslint": "^9.8.0",
+                "globals": "^15.9.0",
                 "prisma": "^5.0.0",
-                "typescript": "^5.1.6",
-                "vitest": "^0.34.0"
+                "typescript": "^5.5.4",
+                "vitest": "^2.0.5"
             },
             "peerDependencies": {
                 "@prisma/client": ">=5.0.0"
@@ -412,24 +416,82 @@
             }
         },
         "node_modules/@eslint-community/regexpp": {
-            "version": "4.8.0",
-            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.8.0.tgz",
-            "integrity": "sha512-JylOEEzDiOryeUnFbQz+oViCXS0KsvR1mvHkoMiu5+UiBvy+RYX7tzlIIIEstF/gVa2tj9AQXk3dgnxv6KxhFg==",
+            "version": "4.12.1",
+            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+            "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
             }
         },
-        "node_modules/@eslint/eslintrc": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.2.tgz",
-            "integrity": "sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==",
+        "node_modules/@eslint/compat": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-1.3.1.tgz",
+            "integrity": "sha512-k8MHony59I5EPic6EQTCNOuPoVBnoYXkP+20xvwFjN7t0qI3ImyvyBgg+hIVPwC8JaxVjjUZld+cLfBLFDLucg==",
             "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "peerDependencies": {
+                "eslint": "^8.40 || 9"
+            },
+            "peerDependenciesMeta": {
+                "eslint": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@eslint/config-array": {
+            "version": "0.21.0",
+            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.0.tgz",
+            "integrity": "sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@eslint/object-schema": "^2.1.6",
+                "debug": "^4.3.1",
+                "minimatch": "^3.1.2"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@eslint/config-helpers": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.0.tgz",
+            "integrity": "sha512-ViuymvFmcJi04qdZeDc2whTHryouGcDlaxPqarTD0ZE10ISpxGUVZGZDx4w01upyIynL3iu6IXH2bS1NhclQMw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@eslint/core": {
+            "version": "0.15.1",
+            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.1.tgz",
+            "integrity": "sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@types/json-schema": "^7.0.15"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@eslint/eslintrc": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
+            "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
+            "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "ajv": "^6.12.4",
                 "debug": "^4.3.2",
-                "espree": "^9.6.0",
-                "globals": "^13.19.0",
+                "espree": "^10.0.1",
+                "globals": "^14.0.0",
                 "ignore": "^5.2.0",
                 "import-fresh": "^3.2.1",
                 "js-yaml": "^4.1.0",
@@ -437,33 +499,98 @@
                 "strip-json-comments": "^3.1.1"
             },
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
             }
         },
-        "node_modules/@eslint/js": {
-            "version": "8.48.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.48.0.tgz",
-            "integrity": "sha512-ZSjtmelB7IJfWD2Fvb7+Z+ChTIKWq6kjda95fLcQKNS5aheVHn4IkfgRQE3sIIzTcSLwLcLZUD9UBt+V7+h+Pw==",
+        "node_modules/@eslint/eslintrc/node_modules/globals": {
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+            "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/@humanwhocodes/config-array": {
-            "version": "0.11.10",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
-            "integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
+        "node_modules/@eslint/js": {
+            "version": "9.32.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.32.0.tgz",
+            "integrity": "sha512-BBpRFZK3eX6uMLKz8WxFOBIFFcGFJ/g8XuwjTHCqHROSIsopI+ddn/d5Cfh36+7+e5edVS8dbSHnBNhrLEX0zg==",
             "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://eslint.org/donate"
+            }
+        },
+        "node_modules/@eslint/object-schema": {
+            "version": "2.1.6",
+            "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
+            "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@eslint/plugin-kit": {
+            "version": "0.3.4",
+            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.4.tgz",
+            "integrity": "sha512-Ul5l+lHEcw3L5+k8POx6r74mxEYKG5kOb6Xpy2gCRW6zweT6TEhAf8vhxGgjhqrd/VO/Dirhsb+1hNpD1ue9hw==",
+            "dev": true,
+            "license": "Apache-2.0",
             "dependencies": {
-                "@humanwhocodes/object-schema": "^1.2.1",
-                "debug": "^4.1.1",
-                "minimatch": "^3.0.5"
+                "@eslint/core": "^0.15.1",
+                "levn": "^0.4.1"
             },
             "engines": {
-                "node": ">=10.10.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@humanfs/core": {
+            "version": "0.19.1",
+            "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+            "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18.18.0"
+            }
+        },
+        "node_modules/@humanfs/node": {
+            "version": "0.16.6",
+            "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
+            "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@humanfs/core": "^0.19.1",
+                "@humanwhocodes/retry": "^0.3.0"
+            },
+            "engines": {
+                "node": ">=18.18.0"
+            }
+        },
+        "node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
+            "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18.18"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/nzakas"
             }
         },
         "node_modules/@humanwhocodes/module-importer": {
@@ -479,64 +606,26 @@
                 "url": "https://github.com/sponsors/nzakas"
             }
         },
-        "node_modules/@humanwhocodes/object-schema": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-            "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
-            "dev": true
-        },
-        "node_modules/@jest/schemas": {
-            "version": "29.6.0",
-            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.0.tgz",
-            "integrity": "sha512-rxLjXyJBTL4LQeJW3aKo0M/+GkCOXsO+8i9Iu7eDb6KwtP65ayoDsitrdPBtujxQ88k4wI2FNYfa6TOGwSn6cQ==",
+        "node_modules/@humanwhocodes/retry": {
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+            "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
             "dev": true,
-            "dependencies": {
-                "@sinclair/typebox": "^0.27.8"
-            },
+            "license": "Apache-2.0",
             "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+                "node": ">=18.18"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/nzakas"
             }
         },
         "node_modules/@jridgewell/sourcemap-codec": {
-            "version": "1.4.15",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-            "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-            "dev": true
-        },
-        "node_modules/@nodelib/fs.scandir": {
-            "version": "2.1.5",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-            "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+            "version": "1.5.4",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
+            "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
             "dev": true,
-            "dependencies": {
-                "@nodelib/fs.stat": "2.0.5",
-                "run-parallel": "^1.1.9"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/@nodelib/fs.stat": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-            "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-            "dev": true,
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/@nodelib/fs.walk": {
-            "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-            "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-            "dev": true,
-            "dependencies": {
-                "@nodelib/fs.scandir": "2.1.5",
-                "fastq": "^1.6.0"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
+            "license": "MIT"
         },
         "node_modules/@prisma/client": {
             "version": "5.0.0",
@@ -572,133 +661,429 @@
             "integrity": "sha512-HHiUF6NixsldsP3JROq07TYBLEjXFKr6PdH8H4gK/XAoTmIplOJBCgrIUMrsRAnEuGyRoRLXKXWUb943+PFoKQ==",
             "peer": true
         },
-        "node_modules/@sinclair/typebox": {
-            "version": "0.27.8",
-            "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-            "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
-            "dev": true
-        },
-        "node_modules/@types/chai": {
-            "version": "4.3.5",
-            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.5.tgz",
-            "integrity": "sha512-mEo1sAde+UCE6b2hxn332f1g1E8WfYRu6p5SvTKr2ZKC1f7gFJXk4h5PyGP9Dt6gCaG8y8XhwnXWC6Iy2cmBng==",
-            "dev": true
-        },
-        "node_modules/@types/chai-subset": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/@types/chai-subset/-/chai-subset-1.3.3.tgz",
-            "integrity": "sha512-frBecisrNGz+F4T6bcc+NLeolfiojh5FxW2klu669+8BARtyQv2C/GkNW6FUodVe4BroGMP/wER/YDGc7rEllw==",
+        "node_modules/@rollup/rollup-android-arm-eabi": {
+            "version": "4.46.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.46.2.tgz",
+            "integrity": "sha512-Zj3Hl6sN34xJtMv7Anwb5Gu01yujyE/cLBDB2gnHTAHaWS1Z38L7kuSG+oAh0giZMqG060f/YBStXtMH6FvPMA==",
+            "cpu": [
+                "arm"
+            ],
             "dev": true,
-            "dependencies": {
-                "@types/chai": "*"
-            }
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@rollup/rollup-android-arm64": {
+            "version": "4.46.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.46.2.tgz",
+            "integrity": "sha512-nTeCWY83kN64oQ5MGz3CgtPx8NSOhC5lWtsjTs+8JAJNLcP3QbLCtDDgUKQc/Ro/frpMq4SHUaHN6AMltcEoLQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@rollup/rollup-darwin-arm64": {
+            "version": "4.46.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.46.2.tgz",
+            "integrity": "sha512-HV7bW2Fb/F5KPdM/9bApunQh68YVDU8sO8BvcW9OngQVN3HHHkw99wFupuUJfGR9pYLLAjcAOA6iO+evsbBaPQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rollup/rollup-darwin-x64": {
+            "version": "4.46.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.46.2.tgz",
+            "integrity": "sha512-SSj8TlYV5nJixSsm/y3QXfhspSiLYP11zpfwp6G/YDXctf3Xkdnk4woJIF5VQe0of2OjzTt8EsxnJDCdHd2xMA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rollup/rollup-freebsd-arm64": {
+            "version": "4.46.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.46.2.tgz",
+            "integrity": "sha512-ZyrsG4TIT9xnOlLsSSi9w/X29tCbK1yegE49RYm3tu3wF1L/B6LVMqnEWyDB26d9Ecx9zrmXCiPmIabVuLmNSg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-freebsd-x64": {
+            "version": "4.46.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.46.2.tgz",
+            "integrity": "sha512-pCgHFoOECwVCJ5GFq8+gR8SBKnMO+xe5UEqbemxBpCKYQddRQMgomv1104RnLSg7nNvgKy05sLsY51+OVRyiVw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+            "version": "4.46.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.46.2.tgz",
+            "integrity": "sha512-EtP8aquZ0xQg0ETFcxUbU71MZlHaw9MChwrQzatiE8U/bvi5uv/oChExXC4mWhjiqK7azGJBqU0tt5H123SzVA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+            "version": "4.46.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.46.2.tgz",
+            "integrity": "sha512-qO7F7U3u1nfxYRPM8HqFtLd+raev2K137dsV08q/LRKRLEc7RsiDWihUnrINdsWQxPR9jqZ8DIIZ1zJJAm5PjQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm64-gnu": {
+            "version": "4.46.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.46.2.tgz",
+            "integrity": "sha512-3dRaqLfcOXYsfvw5xMrxAk9Lb1f395gkoBYzSFcc/scgRFptRXL9DOaDpMiehf9CO8ZDRJW2z45b6fpU5nwjng==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm64-musl": {
+            "version": "4.46.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.46.2.tgz",
+            "integrity": "sha512-fhHFTutA7SM+IrR6lIfiHskxmpmPTJUXpWIsBXpeEwNgZzZZSg/q4i6FU4J8qOGyJ0TR+wXBwx/L7Ho9z0+uDg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
+            "version": "4.46.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.46.2.tgz",
+            "integrity": "sha512-i7wfGFXu8x4+FRqPymzjD+Hyav8l95UIZ773j7J7zRYc3Xsxy2wIn4x+llpunexXe6laaO72iEjeeGyUFmjKeA==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+            "version": "4.46.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.46.2.tgz",
+            "integrity": "sha512-B/l0dFcHVUnqcGZWKcWBSV2PF01YUt0Rvlurci5P+neqY/yMKchGU8ullZvIv5e8Y1C6wOn+U03mrDylP5q9Yw==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+            "version": "4.46.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.46.2.tgz",
+            "integrity": "sha512-32k4ENb5ygtkMwPMucAb8MtV8olkPT03oiTxJbgkJa7lJ7dZMr0GCFJlyvy+K8iq7F/iuOr41ZdUHaOiqyR3iQ==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-riscv64-musl": {
+            "version": "4.46.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.46.2.tgz",
+            "integrity": "sha512-t5B2loThlFEauloaQkZg9gxV05BYeITLvLkWOkRXogP4qHXLkWSbSHKM9S6H1schf/0YGP/qNKtiISlxvfmmZw==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-s390x-gnu": {
+            "version": "4.46.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.46.2.tgz",
+            "integrity": "sha512-YKjekwTEKgbB7n17gmODSmJVUIvj8CX7q5442/CK80L8nqOUbMtf8b01QkG3jOqyr1rotrAnW6B/qiHwfcuWQA==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-x64-gnu": {
+            "version": "4.46.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.46.2.tgz",
+            "integrity": "sha512-Jj5a9RUoe5ra+MEyERkDKLwTXVu6s3aACP51nkfnK9wJTraCC8IMe3snOfALkrjTYd2G1ViE1hICj0fZ7ALBPA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-x64-musl": {
+            "version": "4.46.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.46.2.tgz",
+            "integrity": "sha512-7kX69DIrBeD7yNp4A5b81izs8BqoZkCIaxQaOpumcJ1S/kmqNFjPhDu1LHeVXv0SexfHQv5cqHsxLOjETuqDuA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-arm64-msvc": {
+            "version": "4.46.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.46.2.tgz",
+            "integrity": "sha512-wiJWMIpeaak/jsbaq2HMh/rzZxHVW1rU6coyeNNpMwk5isiPjSTx0a4YLSlYDwBH/WBvLz+EtsNqQScZTLJy3g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-ia32-msvc": {
+            "version": "4.46.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.46.2.tgz",
+            "integrity": "sha512-gBgaUDESVzMgWZhcyjfs9QFK16D8K6QZpwAaVNJxYDLHWayOta4ZMjGm/vsAEy3hvlS2GosVFlBlP9/Wb85DqQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-x64-msvc": {
+            "version": "4.46.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.46.2.tgz",
+            "integrity": "sha512-CvUo2ixeIQGtF6WvuB87XWqPQkoFAFqW+HUo/WzHwuHDvIwZCtjdWXoYCcr06iKGydiqTclC4jU/TNObC/xKZg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@types/estree": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+            "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/json-schema": {
+            "version": "7.0.15",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+            "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "20.4.1",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.1.tgz",
-            "integrity": "sha512-JIzsAvJeA/5iY6Y/OxZbv1lUcc8dNSE77lb2gnBH+/PJ3lFR1Ccvgwl5JWnHAkNHcRsT0TbpVOsiMKZ1F/yyJg==",
-            "dev": true
+            "version": "22.17.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.17.0.tgz",
+            "integrity": "sha512-bbAKTCqX5aNVryi7qXVMi+OkB3w/OyblodicMbvE38blyAz7GxXf6XYhklokijuPwwVg9sDLKRxt0ZHXQwZVfQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "undici-types": "~6.21.0"
+            }
         },
         "node_modules/@vitest/expect": {
-            "version": "0.34.3",
-            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-0.34.3.tgz",
-            "integrity": "sha512-F8MTXZUYRBVsYL1uoIft1HHWhwDbSzwAU9Zgh8S6WFC3YgVb4AnFV2GXO3P5Em8FjEYaZtTnQYoNwwBrlOMXgg==",
+            "version": "2.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+            "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@vitest/spy": "0.34.3",
-                "@vitest/utils": "0.34.3",
-                "chai": "^4.3.7"
+                "@vitest/spy": "2.1.9",
+                "@vitest/utils": "2.1.9",
+                "chai": "^5.1.2",
+                "tinyrainbow": "^1.2.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/mocker": {
+            "version": "2.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+            "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/spy": "2.1.9",
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.12"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "msw": "^2.4.9",
+                "vite": "^5.0.0"
+            },
+            "peerDependenciesMeta": {
+                "msw": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@vitest/pretty-format": {
+            "version": "2.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+            "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyrainbow": "^1.2.0"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
             }
         },
         "node_modules/@vitest/runner": {
-            "version": "0.34.3",
-            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-0.34.3.tgz",
-            "integrity": "sha512-lYNq7N3vR57VMKMPLVvmJoiN4bqwzZ1euTW+XXYH5kzr3W/+xQG3b41xJn9ChJ3AhYOSoweu974S1V3qDcFESA==",
+            "version": "2.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+            "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@vitest/utils": "0.34.3",
-                "p-limit": "^4.0.0",
-                "pathe": "^1.1.1"
+                "@vitest/utils": "2.1.9",
+                "pathe": "^1.1.2"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
             }
         },
-        "node_modules/@vitest/runner/node_modules/p-limit": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
-            "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
-            "dev": true,
-            "dependencies": {
-                "yocto-queue": "^1.0.0"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@vitest/runner/node_modules/yocto-queue": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
-            "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
-            "dev": true,
-            "engines": {
-                "node": ">=12.20"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/@vitest/snapshot": {
-            "version": "0.34.3",
-            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-0.34.3.tgz",
-            "integrity": "sha512-QyPaE15DQwbnIBp/yNJ8lbvXTZxS00kRly0kfFgAD5EYmCbYcA+1EEyRalc93M0gosL/xHeg3lKAClIXYpmUiQ==",
+            "version": "2.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+            "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "magic-string": "^0.30.1",
-                "pathe": "^1.1.1",
-                "pretty-format": "^29.5.0"
+                "@vitest/pretty-format": "2.1.9",
+                "magic-string": "^0.30.12",
+                "pathe": "^1.1.2"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
             }
         },
         "node_modules/@vitest/spy": {
-            "version": "0.34.3",
-            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-0.34.3.tgz",
-            "integrity": "sha512-N1V0RFQ6AI7CPgzBq9kzjRdPIgThC340DGjdKdPSE8r86aUSmeliTUgkTqLSgtEwWWsGfBQ+UetZWhK0BgJmkQ==",
+            "version": "2.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+            "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "tinyspy": "^2.1.1"
+                "tinyspy": "^3.0.2"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
             }
         },
         "node_modules/@vitest/utils": {
-            "version": "0.34.3",
-            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-0.34.3.tgz",
-            "integrity": "sha512-kiSnzLG6m/tiT0XEl4U2H8JDBjFtwVlaE8I3QfGiMFR0QvnRDfYfdP3YvTBWM/6iJDAyaPY6yVQiCTUc7ZzTHA==",
+            "version": "2.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+            "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "diff-sequences": "^29.4.3",
-                "loupe": "^2.3.6",
-                "pretty-format": "^29.5.0"
+                "@vitest/pretty-format": "2.1.9",
+                "loupe": "^3.1.2",
+                "tinyrainbow": "^1.2.0"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
             }
         },
         "node_modules/acorn": {
-            "version": "8.9.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.9.0.tgz",
-            "integrity": "sha512-jaVNAFBHNLXspO543WnNNPZFRtavh3skAkITqD0/2aeMkKZTN+254PyhwxFYrk3vQ1xfY+2wbesJMs/JC8/PwQ==",
+            "version": "8.15.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+            "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
+            "license": "MIT",
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -711,17 +1096,9 @@
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
             "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
             "dev": true,
+            "license": "MIT",
             "peerDependencies": {
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-            }
-        },
-        "node_modules/acorn-walk": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-            "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.4.0"
             }
         },
         "node_modules/ajv": {
@@ -729,6 +1106,7 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -738,15 +1116,6 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/ansi-styles": {
@@ -768,28 +1137,32 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-            "dev": true
+            "dev": true,
+            "license": "Python-2.0"
         },
         "node_modules/assertion-error": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-            "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+            "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
-                "node": "*"
+                "node": ">=12"
             }
         },
         "node_modules/balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -800,6 +1173,7 @@
             "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
             "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
@@ -809,26 +1183,26 @@
             "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
             "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
         },
         "node_modules/chai": {
-            "version": "4.3.7",
-            "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
-            "integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-5.2.1.tgz",
+            "integrity": "sha512-5nFxhUrX0PqtyogoYOA8IPswy5sZFTOsBFl/9bNsmDLgsxYTzSZQJDPppDnZPTQbzSEm0hqGjWPzRemQCYbD6A==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "assertion-error": "^1.1.0",
-                "check-error": "^1.0.2",
-                "deep-eql": "^4.1.2",
-                "get-func-name": "^2.0.0",
-                "loupe": "^2.3.1",
-                "pathval": "^1.1.1",
-                "type-detect": "^4.0.5"
+                "assertion-error": "^2.0.1",
+                "check-error": "^2.1.1",
+                "deep-eql": "^5.0.1",
+                "loupe": "^3.1.0",
+                "pathval": "^2.0.0"
             },
             "engines": {
-                "node": ">=4"
+                "node": ">=18"
             }
         },
         "node_modules/chalk": {
@@ -848,12 +1222,13 @@
             }
         },
         "node_modules/check-error": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-            "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+            "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
             "dev": true,
+            "license": "MIT",
             "engines": {
-                "node": "*"
+                "node": ">= 16"
             }
         },
         "node_modules/color-convert": {
@@ -878,13 +1253,15 @@
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/cross-spawn": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-            "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "path-key": "^3.1.0",
                 "shebang-command": "^2.0.0",
@@ -895,12 +1272,13 @@
             }
         },
         "node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+            "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "ms": "2.1.2"
+                "ms": "^2.1.3"
             },
             "engines": {
                 "node": ">=6.0"
@@ -912,13 +1290,11 @@
             }
         },
         "node_modules/deep-eql": {
-            "version": "4.1.3",
-            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
-            "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+            "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
             "dev": true,
-            "dependencies": {
-                "type-detect": "^4.0.0"
-            },
+            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
@@ -929,26 +1305,12 @@
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
             "dev": true
         },
-        "node_modules/diff-sequences": {
-            "version": "29.6.3",
-            "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
-            "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+        "node_modules/es-module-lexer": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+            "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
             "dev": true,
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/doctrine": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
-            "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-            "dev": true,
-            "dependencies": {
-                "esutils": "^2.0.2"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
+            "license": "MIT"
         },
         "node_modules/esbuild": {
             "version": "0.20.2",
@@ -1001,70 +1363,78 @@
             }
         },
         "node_modules/eslint": {
-            "version": "8.48.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.48.0.tgz",
-            "integrity": "sha512-sb6DLeIuRXxeM1YljSe1KEx9/YYeZFQWcV8Rq9HfigmdDEugjLEVEa1ozDjL6YDjBpQHPJxJzze+alxi4T3OLg==",
+            "version": "9.32.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.32.0.tgz",
+            "integrity": "sha512-LSehfdpgMeWcTZkWZVIJl+tkZ2nuSkyyB9C27MZqFWXuph7DvaowgcTvKqxvpLW1JZIk8PN7hFY3Rj9LQ7m7lg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
-                "@eslint-community/regexpp": "^4.6.1",
-                "@eslint/eslintrc": "^2.1.2",
-                "@eslint/js": "8.48.0",
-                "@humanwhocodes/config-array": "^0.11.10",
+                "@eslint-community/regexpp": "^4.12.1",
+                "@eslint/config-array": "^0.21.0",
+                "@eslint/config-helpers": "^0.3.0",
+                "@eslint/core": "^0.15.0",
+                "@eslint/eslintrc": "^3.3.1",
+                "@eslint/js": "9.32.0",
+                "@eslint/plugin-kit": "^0.3.4",
+                "@humanfs/node": "^0.16.6",
                 "@humanwhocodes/module-importer": "^1.0.1",
-                "@nodelib/fs.walk": "^1.2.8",
+                "@humanwhocodes/retry": "^0.4.2",
+                "@types/estree": "^1.0.6",
+                "@types/json-schema": "^7.0.15",
                 "ajv": "^6.12.4",
                 "chalk": "^4.0.0",
-                "cross-spawn": "^7.0.2",
+                "cross-spawn": "^7.0.6",
                 "debug": "^4.3.2",
-                "doctrine": "^3.0.0",
                 "escape-string-regexp": "^4.0.0",
-                "eslint-scope": "^7.2.2",
-                "eslint-visitor-keys": "^3.4.3",
-                "espree": "^9.6.1",
-                "esquery": "^1.4.2",
+                "eslint-scope": "^8.4.0",
+                "eslint-visitor-keys": "^4.2.1",
+                "espree": "^10.4.0",
+                "esquery": "^1.5.0",
                 "esutils": "^2.0.2",
                 "fast-deep-equal": "^3.1.3",
-                "file-entry-cache": "^6.0.1",
+                "file-entry-cache": "^8.0.0",
                 "find-up": "^5.0.0",
                 "glob-parent": "^6.0.2",
-                "globals": "^13.19.0",
-                "graphemer": "^1.4.0",
                 "ignore": "^5.2.0",
                 "imurmurhash": "^0.1.4",
                 "is-glob": "^4.0.0",
-                "is-path-inside": "^3.0.3",
-                "js-yaml": "^4.1.0",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
-                "levn": "^0.4.1",
                 "lodash.merge": "^4.6.2",
                 "minimatch": "^3.1.2",
                 "natural-compare": "^1.4.0",
-                "optionator": "^0.9.3",
-                "strip-ansi": "^6.0.1",
-                "text-table": "^0.2.0"
+                "optionator": "^0.9.3"
             },
             "bin": {
                 "eslint": "bin/eslint.js"
             },
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
-                "url": "https://opencollective.com/eslint"
+                "url": "https://eslint.org/donate"
+            },
+            "peerDependencies": {
+                "jiti": "*"
+            },
+            "peerDependenciesMeta": {
+                "jiti": {
+                    "optional": true
+                }
             }
         },
         "node_modules/eslint-scope": {
-            "version": "7.2.2",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
-            "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+            "version": "8.4.0",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+            "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
             "dev": true,
+            "license": "BSD-2-Clause",
             "dependencies": {
                 "esrecurse": "^4.3.0",
                 "estraverse": "^5.2.0"
             },
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
@@ -1082,18 +1452,45 @@
                 "url": "https://opencollective.com/eslint"
             }
         },
-        "node_modules/espree": {
-            "version": "9.6.1",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
-            "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+        "node_modules/eslint/node_modules/eslint-visitor-keys": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+            "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
             "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/espree": {
+            "version": "10.4.0",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+            "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+            "dev": true,
+            "license": "BSD-2-Clause",
             "dependencies": {
-                "acorn": "^8.9.0",
+                "acorn": "^8.15.0",
                 "acorn-jsx": "^5.3.2",
-                "eslint-visitor-keys": "^3.4.1"
+                "eslint-visitor-keys": "^4.2.1"
             },
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/espree/node_modules/eslint-visitor-keys": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+            "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
@@ -1116,6 +1513,7 @@
             "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
             "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
             "dev": true,
+            "license": "BSD-2-Clause",
             "dependencies": {
                 "estraverse": "^5.2.0"
             },
@@ -1132,26 +1530,49 @@
                 "node": ">=4.0"
             }
         },
+        "node_modules/estree-walker": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0"
+            }
+        },
         "node_modules/esutils": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
             "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
             "dev": true,
+            "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/expect-type": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
+            "integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=12.0.0"
             }
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/fast-json-stable-stringify": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
             "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/fast-levenshtein": {
             "version": "2.0.6",
@@ -1159,25 +1580,17 @@
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "dev": true
         },
-        "node_modules/fastq": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
-            "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
-            "dev": true,
-            "dependencies": {
-                "reusify": "^1.0.4"
-            }
-        },
         "node_modules/file-entry-cache": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
-            "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+            "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "flat-cache": "^3.0.4"
+                "flat-cache": "^4.0.0"
             },
             "engines": {
-                "node": "^10.12.0 || >=12.0.0"
+                "node": ">=16.0.0"
             }
         },
         "node_modules/find-up": {
@@ -1197,71 +1610,39 @@
             }
         },
         "node_modules/flat-cache": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
-            "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+            "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "flatted": "^3.1.0",
-                "rimraf": "^3.0.2"
+                "flatted": "^3.2.9",
+                "keyv": "^4.5.4"
             },
             "engines": {
-                "node": "^10.12.0 || >=12.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/flatted": {
-            "version": "3.2.7",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
-            "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
-            "dev": true
-        },
-        "node_modules/fs.realpath": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-            "dev": true
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+            "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/fsevents": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
             "dev": true,
             "hasInstallScript": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
             ],
             "engines": {
                 "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-            }
-        },
-        "node_modules/get-func-name": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-            "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
-            "dev": true,
-            "engines": {
-                "node": "*"
-            }
-        },
-        "node_modules/glob": {
-            "version": "7.2.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-            "dev": true,
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.1.1",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-            },
-            "engines": {
-                "node": "*"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/glob-parent": {
@@ -1277,25 +1658,17 @@
             }
         },
         "node_modules/globals": {
-            "version": "13.21.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-13.21.0.tgz",
-            "integrity": "sha512-ybyme3s4yy/t/3s35bewwXKOf7cvzfreG2lH0lZl0JB7I4GxRP2ghxOK/Nb9EkRXdbBXZLfq/p/0W2JUONB/Gg==",
+            "version": "15.15.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
+            "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
             "dev": true,
-            "dependencies": {
-                "type-fest": "^0.20.2"
-            },
+            "license": "MIT",
             "engines": {
-                "node": ">=8"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
-        },
-        "node_modules/graphemer": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
-            "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
-            "dev": true
         },
         "node_modules/has-flag": {
             "version": "4.0.0",
@@ -1307,19 +1680,21 @@
             }
         },
         "node_modules/ignore": {
-            "version": "5.2.4",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
-            "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+            "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">= 4"
             }
         },
         "node_modules/import-fresh": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-            "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+            "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "parent-module": "^1.0.0",
                 "resolve-from": "^4.0.0"
@@ -1339,22 +1714,6 @@
             "engines": {
                 "node": ">=0.8.19"
             }
-        },
-        "node_modules/inflight": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-            "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-            "dev": true,
-            "dependencies": {
-                "once": "^1.3.0",
-                "wrappy": "1"
-            }
-        },
-        "node_modules/inherits": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "dev": true
         },
         "node_modules/is-extglob": {
             "version": "2.1.1",
@@ -1377,26 +1736,19 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/is-path-inside": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
-            "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-            "dev": true
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/js-yaml": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
             "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1"
             },
@@ -1404,11 +1756,19 @@
                 "js-yaml": "bin/js-yaml.js"
             }
         },
+        "node_modules/json-buffer": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+            "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/json-schema-traverse": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
@@ -1416,11 +1776,15 @@
             "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
             "dev": true
         },
-        "node_modules/jsonc-parser": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
-            "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
-            "dev": true
+        "node_modules/keyv": {
+            "version": "4.5.4",
+            "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+            "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "json-buffer": "3.0.1"
+            }
         },
         "node_modules/levn": {
             "version": "0.4.1",
@@ -1433,18 +1797,6 @@
             },
             "engines": {
                 "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/local-pkg": {
-            "version": "0.4.3",
-            "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.4.3.tgz",
-            "integrity": "sha512-SFppqq5p42fe2qcZQqqEOiVRXl+WCP1MdT6k7BDEW1j++sp5fIY+/fdRQitvKgB5BrBcmrs5m/L0v2FrU5MY1g==",
-            "dev": true,
-            "engines": {
-                "node": ">=14"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
             }
         },
         "node_modules/locate-path": {
@@ -1469,24 +1821,20 @@
             "dev": true
         },
         "node_modules/loupe": {
-            "version": "2.3.6",
-            "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
-            "integrity": "sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.0.tgz",
+            "integrity": "sha512-2NCfZcT5VGVNX9mSZIxLRkEAegDGBpuQZBy13desuHeVORmBDyAET4TkJr4SjqQy3A8JDofMN6LpkK8Xcm/dlw==",
             "dev": true,
-            "dependencies": {
-                "get-func-name": "^2.0.0"
-            }
+            "license": "MIT"
         },
         "node_modules/magic-string": {
-            "version": "0.30.1",
-            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.1.tgz",
-            "integrity": "sha512-mbVKXPmS0z0G4XqFDCTllmDQ6coZzn94aMlb0o/A4HEHJCKcanlDZwYJgwnkmgD3jyWhUgj9VsPrfd972yPffA==",
+            "version": "0.30.17",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
+            "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@jridgewell/sourcemap-codec": "^1.4.15"
-            },
-            "engines": {
-                "node": ">=12"
+                "@jridgewell/sourcemap-codec": "^1.5.0"
             }
         },
         "node_modules/minimatch": {
@@ -1494,6 +1842,7 @@
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
             "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -1501,28 +1850,17 @@
                 "node": "*"
             }
         },
-        "node_modules/mlly": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.4.0.tgz",
-            "integrity": "sha512-ua8PAThnTwpprIaU47EPeZ/bPUVp2QYBbWMphUQpVdBI3Lgqzm5KZQ45Agm3YJedHXaIHl6pBGabaLSUPPSptg==",
-            "dev": true,
-            "dependencies": {
-                "acorn": "^8.9.0",
-                "pathe": "^1.1.1",
-                "pkg-types": "^1.0.3",
-                "ufo": "^1.1.2"
-            }
-        },
         "node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/nanoid": {
-            "version": "3.3.6",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-            "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+            "version": "3.3.11",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
             "dev": true,
             "funding": [
                 {
@@ -1530,6 +1868,7 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "license": "MIT",
             "bin": {
                 "nanoid": "bin/nanoid.cjs"
             },
@@ -1542,15 +1881,6 @@
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
             "dev": true
-        },
-        "node_modules/once": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-            "dev": true,
-            "dependencies": {
-                "wrappy": "1"
-            }
         },
         "node_modules/optionator": {
             "version": "0.9.3",
@@ -1604,6 +1934,7 @@
             "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
             "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "callsites": "^3.0.0"
             },
@@ -1620,60 +1951,44 @@
                 "node": ">=8"
             }
         },
-        "node_modules/path-is-absolute": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/path-key": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
             "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/pathe": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.1.tgz",
-            "integrity": "sha512-d+RQGp0MAYTIaDBIMmOfMwz3E+LOZnxx1HZd5R18mmCZY0QBlK0LDZfPc8FW8Ed2DlvsuE6PRjroDY+wg4+j/Q==",
-            "dev": true
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+            "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/pathval": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-            "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+            "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
-                "node": "*"
+                "node": ">= 14.16"
             }
         },
         "node_modules/picocolors": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-            "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-            "dev": true
-        },
-        "node_modules/pkg-types": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.0.3.tgz",
-            "integrity": "sha512-nN7pYi0AQqJnoLPC9eHFQ8AcyaixBUOwvqc5TDnIKCMEE6I0y8P7OKA7fPexsXGCGxQDl/cmrLAp26LhcwxZ4A==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
             "dev": true,
-            "dependencies": {
-                "jsonc-parser": "^3.2.0",
-                "mlly": "^1.2.0",
-                "pathe": "^1.1.0"
-            }
+            "license": "ISC"
         },
         "node_modules/postcss": {
-            "version": "8.4.25",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.25.tgz",
-            "integrity": "sha512-7taJ/8t2av0Z+sQEvNzCkpDynl0tX3uJMCODi6nT3PfASC7dYCWV9aQ+uiCf+KBD4SEFcu+GvJdGdwzQ6OSjCw==",
+            "version": "8.5.6",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+            "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
             "dev": true,
             "funding": [
                 {
@@ -1689,10 +2004,11 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.6",
-                "picocolors": "^1.0.0",
-                "source-map-js": "^1.0.2"
+                "nanoid": "^3.3.11",
+                "picocolors": "^1.1.1",
+                "source-map-js": "^1.2.1"
             },
             "engines": {
                 "node": "^10 || ^12 || >=14"
@@ -1705,32 +2021,6 @@
             "dev": true,
             "engines": {
                 "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/pretty-format": {
-            "version": "29.6.1",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.1.tgz",
-            "integrity": "sha512-7jRj+yXO0W7e4/tSJKoR7HRIHLPPjtNaUGG2xxKQnGvPNRkgWcQ0AZX6P4KBRJN4FcTBWb3sa7DVUJmocYuoog==",
-            "dev": true,
-            "dependencies": {
-                "@jest/schemas": "^29.6.0",
-                "ansi-styles": "^5.0.0",
-                "react-is": "^18.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/pretty-format/node_modules/ansi-styles": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
         "node_modules/prisma": {
@@ -1750,111 +2040,63 @@
             }
         },
         "node_modules/punycode": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-            "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+            "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
-        },
-        "node_modules/queue-microtask": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-            "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ]
-        },
-        "node_modules/react-is": {
-            "version": "18.2.0",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-            "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
-            "dev": true
         },
         "node_modules/resolve-from": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
             "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=4"
             }
         },
-        "node_modules/reusify": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-            "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-            "dev": true,
-            "engines": {
-                "iojs": ">=1.0.0",
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/rimraf": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-            "dev": true,
-            "dependencies": {
-                "glob": "^7.1.3"
-            },
-            "bin": {
-                "rimraf": "bin.js"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/rollup": {
-            "version": "3.26.2",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.26.2.tgz",
-            "integrity": "sha512-6umBIGVz93er97pMgQO08LuH3m6PUb3jlDUUGFsNJB6VgTCUaDFpupf5JfU30529m/UKOgmiX+uY6Sx8cOYpLA==",
+            "version": "4.46.2",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.46.2.tgz",
+            "integrity": "sha512-WMmLFI+Boh6xbop+OAGo9cQ3OgX9MIg7xOQjn+pTCwOkk+FNDAeAemXkJ3HzDJrVXleLOFVa1ipuc1AmEx1Dwg==",
             "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "1.0.8"
+            },
             "bin": {
                 "rollup": "dist/bin/rollup"
             },
             "engines": {
-                "node": ">=14.18.0",
+                "node": ">=18.0.0",
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
+                "@rollup/rollup-android-arm-eabi": "4.46.2",
+                "@rollup/rollup-android-arm64": "4.46.2",
+                "@rollup/rollup-darwin-arm64": "4.46.2",
+                "@rollup/rollup-darwin-x64": "4.46.2",
+                "@rollup/rollup-freebsd-arm64": "4.46.2",
+                "@rollup/rollup-freebsd-x64": "4.46.2",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.46.2",
+                "@rollup/rollup-linux-arm-musleabihf": "4.46.2",
+                "@rollup/rollup-linux-arm64-gnu": "4.46.2",
+                "@rollup/rollup-linux-arm64-musl": "4.46.2",
+                "@rollup/rollup-linux-loongarch64-gnu": "4.46.2",
+                "@rollup/rollup-linux-ppc64-gnu": "4.46.2",
+                "@rollup/rollup-linux-riscv64-gnu": "4.46.2",
+                "@rollup/rollup-linux-riscv64-musl": "4.46.2",
+                "@rollup/rollup-linux-s390x-gnu": "4.46.2",
+                "@rollup/rollup-linux-x64-gnu": "4.46.2",
+                "@rollup/rollup-linux-x64-musl": "4.46.2",
+                "@rollup/rollup-win32-arm64-msvc": "4.46.2",
+                "@rollup/rollup-win32-ia32-msvc": "4.46.2",
+                "@rollup/rollup-win32-x64-msvc": "4.46.2",
                 "fsevents": "~2.3.2"
-            }
-        },
-        "node_modules/run-parallel": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-            "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "dependencies": {
-                "queue-microtask": "^1.2.2"
             }
         },
         "node_modules/shebang-command": {
@@ -1862,6 +2104,7 @@
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
             "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "shebang-regex": "^3.0.0"
             },
@@ -1874,6 +2117,7 @@
             "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
@@ -1882,13 +2126,15 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
             "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
-            "dev": true
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/source-map-js": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-            "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+            "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
             "dev": true,
+            "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -1897,48 +2143,27 @@
             "version": "0.0.2",
             "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
             "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/std-env": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.3.3.tgz",
-            "integrity": "sha512-Rz6yejtVyWnVjC1RFvNmYL10kgjC49EOghxWn0RFqlCHGFpQx+Xe7yW3I4ceK1SGrWIGMjD5Kbue8W/udkbMJg==",
-            "dev": true
-        },
-        "node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "version": "3.9.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+            "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
             "dev": true,
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
+            "license": "MIT"
         },
         "node_modules/strip-json-comments": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
             "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/strip-literal": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-1.0.1.tgz",
-            "integrity": "sha512-QZTsipNpa2Ppr6v1AmJHESqJ3Uz247MUS0OjrnnZjFAvEoWqxuyFuXn2xLgMtRnijJShAa1HL0gtJyUs7u7n3Q==",
-            "dev": true,
-            "dependencies": {
-                "acorn": "^8.8.2"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
             }
         },
         "node_modules/supports-color": {
@@ -1953,32 +2178,46 @@
                 "node": ">=8"
             }
         },
-        "node_modules/text-table": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-            "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-            "dev": true
-        },
         "node_modules/tinybench": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.5.0.tgz",
-            "integrity": "sha512-kRwSG8Zx4tjF9ZiyH4bhaebu+EDz1BOx9hOigYHlUW4xxI/wKIUQUqo018UlU4ar6ATPBsaMrdbKZ+tmPdohFA==",
-            "dev": true
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+            "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/tinyexec": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+            "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/tinypool": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.7.0.tgz",
-            "integrity": "sha512-zSYNUlYSMhJ6Zdou4cJwo/p7w5nmAH17GRfU/ui3ctvjXFErXXkruT4MWW6poDeXgCaIBlGLrfU6TbTXxyGMww==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+            "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
             "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.0.0 || >=20.0.0"
+            }
+        },
+        "node_modules/tinyrainbow": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+            "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+            "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=14.0.0"
             }
         },
         "node_modules/tinyspy": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.1.1.tgz",
-            "integrity": "sha512-XPJL2uSzcOyBMky6OFrusqWlzfFrXtE0hPuMgW8A2HmaqrPo4ZQHRN/V0QXN3FSjKxpsbRrFc5LI7KOwBsT1/w==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+            "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=14.0.0"
             }
@@ -1995,32 +2234,12 @@
                 "node": ">= 0.8.0"
             }
         },
-        "node_modules/type-detect": {
-            "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-            "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-            "dev": true,
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/type-fest": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-            "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/typescript": {
-            "version": "5.1.6",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-            "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+            "version": "5.9.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+            "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
             "dev": true,
+            "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -2029,48 +2248,52 @@
                 "node": ">=14.17"
             }
         },
-        "node_modules/ufo": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.1.2.tgz",
-            "integrity": "sha512-TrY6DsjTQQgyS3E3dBaOXf0TpPD8u9FVrVYmKVegJuFw51n/YB9XPt+U6ydzFG5ZIN7+DIjPbNmXoBj9esYhgQ==",
-            "dev": true
+        "node_modules/undici-types": {
+            "version": "6.21.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/uri-js": {
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
             "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
             "dev": true,
+            "license": "BSD-2-Clause",
             "dependencies": {
                 "punycode": "^2.1.0"
             }
         },
         "node_modules/vite": {
-            "version": "4.4.3",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.3.tgz",
-            "integrity": "sha512-IMnXQXXWgLi5brBQx/4WzDxdzW0X3pjO4nqFJAuNvwKtxzAmPzFE1wszW3VDpAGQJm3RZkm/brzRdyGsnwgJIA==",
+            "version": "5.4.19",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.19.tgz",
+            "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "esbuild": "^0.18.10",
-                "postcss": "^8.4.25",
-                "rollup": "^3.25.2"
+                "esbuild": "^0.21.3",
+                "postcss": "^8.4.43",
+                "rollup": "^4.20.0"
             },
             "bin": {
                 "vite": "bin/vite.js"
             },
             "engines": {
-                "node": "^14.18.0 || >=16.0.0"
+                "node": "^18.0.0 || >=20.0.0"
             },
             "funding": {
                 "url": "https://github.com/vitejs/vite?sponsor=1"
             },
             "optionalDependencies": {
-                "fsevents": "~2.3.2"
+                "fsevents": "~2.3.3"
             },
             "peerDependencies": {
-                "@types/node": ">= 14",
+                "@types/node": "^18.0.0 || >=20.0.0",
                 "less": "*",
                 "lightningcss": "^1.21.0",
                 "sass": "*",
+                "sass-embedded": "*",
                 "stylus": "*",
                 "sugarss": "*",
                 "terser": "^5.4.0"
@@ -2088,6 +2311,9 @@
                 "sass": {
                     "optional": true
                 },
+                "sass-embedded": {
+                    "optional": true
+                },
                 "stylus": {
                     "optional": true
                 },
@@ -2100,36 +2326,54 @@
             }
         },
         "node_modules/vite-node": {
-            "version": "0.34.3",
-            "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.34.3.tgz",
-            "integrity": "sha512-+0TzJf1g0tYXj6tR2vEyiA42OPq68QkRZCu/ERSo2PtsDJfBpDyEfuKbRvLmZqi/CgC7SCBtyC+WjTGNMRIaig==",
+            "version": "2.1.9",
+            "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+            "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "cac": "^6.7.14",
-                "debug": "^4.3.4",
-                "mlly": "^1.4.0",
-                "pathe": "^1.1.1",
-                "picocolors": "^1.0.0",
-                "vite": "^3.0.0 || ^4.0.0"
+                "debug": "^4.3.7",
+                "es-module-lexer": "^1.5.4",
+                "pathe": "^1.1.2",
+                "vite": "^5.0.0"
             },
             "bin": {
                 "vite-node": "vite-node.mjs"
             },
             "engines": {
-                "node": ">=v14.18.0"
+                "node": "^18.0.0 || >=20.0.0"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
             }
         },
+        "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+            "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/vite/node_modules/@esbuild/android-arm": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
-            "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+            "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
             "cpu": [
                 "arm"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "android"
@@ -2139,13 +2383,14 @@
             }
         },
         "node_modules/vite/node_modules/@esbuild/android-arm64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
-            "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+            "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "android"
@@ -2155,13 +2400,14 @@
             }
         },
         "node_modules/vite/node_modules/@esbuild/android-x64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
-            "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+            "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "android"
@@ -2171,13 +2417,14 @@
             }
         },
         "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
-            "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+            "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
@@ -2187,13 +2434,14 @@
             }
         },
         "node_modules/vite/node_modules/@esbuild/darwin-x64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
-            "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+            "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
@@ -2203,13 +2451,14 @@
             }
         },
         "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
-            "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+            "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "freebsd"
@@ -2219,13 +2468,14 @@
             }
         },
         "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
-            "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+            "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "freebsd"
@@ -2235,13 +2485,14 @@
             }
         },
         "node_modules/vite/node_modules/@esbuild/linux-arm": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
-            "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+            "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
             "cpu": [
                 "arm"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -2251,13 +2502,14 @@
             }
         },
         "node_modules/vite/node_modules/@esbuild/linux-arm64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
-            "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+            "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -2267,13 +2519,14 @@
             }
         },
         "node_modules/vite/node_modules/@esbuild/linux-ia32": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
-            "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+            "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
             "cpu": [
                 "ia32"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -2283,13 +2536,14 @@
             }
         },
         "node_modules/vite/node_modules/@esbuild/linux-loong64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
-            "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+            "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
             "cpu": [
                 "loong64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -2299,13 +2553,14 @@
             }
         },
         "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
-            "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+            "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
             "cpu": [
                 "mips64el"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -2315,13 +2570,14 @@
             }
         },
         "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
-            "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+            "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
             "cpu": [
                 "ppc64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -2331,13 +2587,14 @@
             }
         },
         "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
-            "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+            "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
             "cpu": [
                 "riscv64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -2347,13 +2604,14 @@
             }
         },
         "node_modules/vite/node_modules/@esbuild/linux-s390x": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
-            "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+            "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
             "cpu": [
                 "s390x"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -2363,13 +2621,14 @@
             }
         },
         "node_modules/vite/node_modules/@esbuild/linux-x64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
-            "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+            "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -2379,13 +2638,14 @@
             }
         },
         "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
-            "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+            "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "netbsd"
@@ -2395,13 +2655,14 @@
             }
         },
         "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
-            "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+            "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "openbsd"
@@ -2411,13 +2672,14 @@
             }
         },
         "node_modules/vite/node_modules/@esbuild/sunos-x64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
-            "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+            "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "sunos"
@@ -2427,13 +2689,14 @@
             }
         },
         "node_modules/vite/node_modules/@esbuild/win32-arm64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
-            "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+            "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
@@ -2443,13 +2706,14 @@
             }
         },
         "node_modules/vite/node_modules/@esbuild/win32-ia32": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
-            "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+            "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
             "cpu": [
                 "ia32"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
@@ -2459,13 +2723,14 @@
             }
         },
         "node_modules/vite/node_modules/@esbuild/win32-x64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
-            "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+            "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
@@ -2475,11 +2740,12 @@
             }
         },
         "node_modules/vite/node_modules/esbuild": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
-            "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+            "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
             "dev": true,
             "hasInstallScript": true,
+            "license": "MIT",
             "bin": {
                 "esbuild": "bin/esbuild"
             },
@@ -2487,82 +2753,81 @@
                 "node": ">=12"
             },
             "optionalDependencies": {
-                "@esbuild/android-arm": "0.18.20",
-                "@esbuild/android-arm64": "0.18.20",
-                "@esbuild/android-x64": "0.18.20",
-                "@esbuild/darwin-arm64": "0.18.20",
-                "@esbuild/darwin-x64": "0.18.20",
-                "@esbuild/freebsd-arm64": "0.18.20",
-                "@esbuild/freebsd-x64": "0.18.20",
-                "@esbuild/linux-arm": "0.18.20",
-                "@esbuild/linux-arm64": "0.18.20",
-                "@esbuild/linux-ia32": "0.18.20",
-                "@esbuild/linux-loong64": "0.18.20",
-                "@esbuild/linux-mips64el": "0.18.20",
-                "@esbuild/linux-ppc64": "0.18.20",
-                "@esbuild/linux-riscv64": "0.18.20",
-                "@esbuild/linux-s390x": "0.18.20",
-                "@esbuild/linux-x64": "0.18.20",
-                "@esbuild/netbsd-x64": "0.18.20",
-                "@esbuild/openbsd-x64": "0.18.20",
-                "@esbuild/sunos-x64": "0.18.20",
-                "@esbuild/win32-arm64": "0.18.20",
-                "@esbuild/win32-ia32": "0.18.20",
-                "@esbuild/win32-x64": "0.18.20"
+                "@esbuild/aix-ppc64": "0.21.5",
+                "@esbuild/android-arm": "0.21.5",
+                "@esbuild/android-arm64": "0.21.5",
+                "@esbuild/android-x64": "0.21.5",
+                "@esbuild/darwin-arm64": "0.21.5",
+                "@esbuild/darwin-x64": "0.21.5",
+                "@esbuild/freebsd-arm64": "0.21.5",
+                "@esbuild/freebsd-x64": "0.21.5",
+                "@esbuild/linux-arm": "0.21.5",
+                "@esbuild/linux-arm64": "0.21.5",
+                "@esbuild/linux-ia32": "0.21.5",
+                "@esbuild/linux-loong64": "0.21.5",
+                "@esbuild/linux-mips64el": "0.21.5",
+                "@esbuild/linux-ppc64": "0.21.5",
+                "@esbuild/linux-riscv64": "0.21.5",
+                "@esbuild/linux-s390x": "0.21.5",
+                "@esbuild/linux-x64": "0.21.5",
+                "@esbuild/netbsd-x64": "0.21.5",
+                "@esbuild/openbsd-x64": "0.21.5",
+                "@esbuild/sunos-x64": "0.21.5",
+                "@esbuild/win32-arm64": "0.21.5",
+                "@esbuild/win32-ia32": "0.21.5",
+                "@esbuild/win32-x64": "0.21.5"
             }
         },
         "node_modules/vitest": {
-            "version": "0.34.3",
-            "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.34.3.tgz",
-            "integrity": "sha512-7+VA5Iw4S3USYk+qwPxHl8plCMhA5rtfwMjgoQXMT7rO5ldWcdsdo3U1QD289JgglGK4WeOzgoLTsGFu6VISyQ==",
+            "version": "2.1.9",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+            "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@types/chai": "^4.3.5",
-                "@types/chai-subset": "^1.3.3",
-                "@types/node": "*",
-                "@vitest/expect": "0.34.3",
-                "@vitest/runner": "0.34.3",
-                "@vitest/snapshot": "0.34.3",
-                "@vitest/spy": "0.34.3",
-                "@vitest/utils": "0.34.3",
-                "acorn": "^8.9.0",
-                "acorn-walk": "^8.2.0",
-                "cac": "^6.7.14",
-                "chai": "^4.3.7",
-                "debug": "^4.3.4",
-                "local-pkg": "^0.4.3",
-                "magic-string": "^0.30.1",
-                "pathe": "^1.1.1",
-                "picocolors": "^1.0.0",
-                "std-env": "^3.3.3",
-                "strip-literal": "^1.0.1",
-                "tinybench": "^2.5.0",
-                "tinypool": "^0.7.0",
-                "vite": "^3.0.0 || ^4.0.0",
-                "vite-node": "0.34.3",
-                "why-is-node-running": "^2.2.2"
+                "@vitest/expect": "2.1.9",
+                "@vitest/mocker": "2.1.9",
+                "@vitest/pretty-format": "^2.1.9",
+                "@vitest/runner": "2.1.9",
+                "@vitest/snapshot": "2.1.9",
+                "@vitest/spy": "2.1.9",
+                "@vitest/utils": "2.1.9",
+                "chai": "^5.1.2",
+                "debug": "^4.3.7",
+                "expect-type": "^1.1.0",
+                "magic-string": "^0.30.12",
+                "pathe": "^1.1.2",
+                "std-env": "^3.8.0",
+                "tinybench": "^2.9.0",
+                "tinyexec": "^0.3.1",
+                "tinypool": "^1.0.1",
+                "tinyrainbow": "^1.2.0",
+                "vite": "^5.0.0",
+                "vite-node": "2.1.9",
+                "why-is-node-running": "^2.3.0"
             },
             "bin": {
                 "vitest": "vitest.mjs"
             },
             "engines": {
-                "node": ">=v14.18.0"
+                "node": "^18.0.0 || >=20.0.0"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
             },
             "peerDependencies": {
                 "@edge-runtime/vm": "*",
-                "@vitest/browser": "*",
-                "@vitest/ui": "*",
+                "@types/node": "^18.0.0 || >=20.0.0",
+                "@vitest/browser": "2.1.9",
+                "@vitest/ui": "2.1.9",
                 "happy-dom": "*",
-                "jsdom": "*",
-                "playwright": "*",
-                "safaridriver": "*",
-                "webdriverio": "*"
+                "jsdom": "*"
             },
             "peerDependenciesMeta": {
                 "@edge-runtime/vm": {
+                    "optional": true
+                },
+                "@types/node": {
                     "optional": true
                 },
                 "@vitest/browser": {
@@ -2576,15 +2841,6 @@
                 },
                 "jsdom": {
                     "optional": true
-                },
-                "playwright": {
-                    "optional": true
-                },
-                "safaridriver": {
-                    "optional": true
-                },
-                "webdriverio": {
-                    "optional": true
                 }
             }
         },
@@ -2593,6 +2849,7 @@
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
             "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "isexe": "^2.0.0"
             },
@@ -2604,10 +2861,11 @@
             }
         },
         "node_modules/why-is-node-running": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.2.2.tgz",
-            "integrity": "sha512-6tSwToZxTOcotxHeA+qGCq1mVzKR3CwcJGmVcY+QE8SHy6TnpFnh8PAvPNHYr7EcuVeG0QSMxtYCuO1ta/G/oA==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+            "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "siginfo": "^2.0.0",
                 "stackback": "0.0.2"
@@ -2618,12 +2876,6 @@
             "engines": {
                 "node": ">=8"
             }
-        },
-        "node_modules/wrappy": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-            "dev": true
         },
         "node_modules/yocto-queue": {
             "version": "0.1.0",

--- a/packages/prisma-extension-bark/package.json
+++ b/packages/prisma-extension-bark/package.json
@@ -41,6 +41,7 @@
     },
     "scripts": {
         "build": "esbuild ./src/index.js --bundle --format=cjs --outfile=dist/index.cjs --platform=node --external:@prisma/client",
+        "postinstall": "npm run build",
         "prepublishOnly": "pnpm build",
         "test": "vitest",
         "prisma:generate": "pnpx prisma generate --schema=./test/setup/schema.prisma",
@@ -50,11 +51,13 @@
     "peerDependencies": {
         "@prisma/client": ">=5.0.0"
     },
+    "dependencies": {
+        "esbuild": "^0.20.0"
+    },
     "devDependencies": {
         "@eslint/compat": "^1.1.1",
         "@eslint/js": "^9.8.0",
         "@types/node": "^22.1.0",
-        "esbuild": "^0.20.0",
         "eslint": "^9.8.0",
         "globals": "^15.9.0",
         "prisma": "^5.0.0",

--- a/packages/prisma-extension-bark/package.json
+++ b/packages/prisma-extension-bark/package.json
@@ -44,6 +44,8 @@
         "postinstall": "npm run build",
         "prepublishOnly": "pnpm build",
         "test": "vitest",
+        "test:ts": "tsc --noEmit -p test/tsconfig.json && vitest run test/typescript-integration.test.ts",
+        "test:all": "npm run test:ts && npm test",
         "prisma:generate": "pnpx prisma generate --schema=./test/setup/schema.prisma",
         "lint:fix": "eslint . --fix",
         "lint": "eslint ."

--- a/packages/prisma-extension-bark/package.json
+++ b/packages/prisma-extension-bark/package.json
@@ -53,13 +53,11 @@
     "peerDependencies": {
         "@prisma/client": ">=5.0.0"
     },
-    "dependencies": {
-        "esbuild": "^0.20.0"
-    },
     "devDependencies": {
         "@eslint/compat": "^1.1.1",
         "@eslint/js": "^9.8.0",
         "@types/node": "^22.1.0",
+        "esbuild": "^0.20.0",
         "eslint": "^9.8.0",
         "globals": "^15.9.0",
         "prisma": "^5.0.0",

--- a/packages/prisma-extension-bark/src/consts.js
+++ b/packages/prisma-extension-bark/src/consts.js
@@ -4,5 +4,4 @@ export const ABC = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ'
 export const min_segment = ABC.at(0)?.repeat(STEP_LENGTH)
 export const max_segment = ABC.at?.(-1)?.repeat(STEP_LENGTH)
 
-/** @type {import('@prisma/client').Prisma.Enumerable<import('@prisma/client').Prisma.nodeOrderByWithRelationInput>} */
 export const default_order_by = { path: 'asc' }

--- a/packages/prisma-extension-bark/src/create/create-child.js
+++ b/packages/prisma-extension-bark/src/create/create-child.js
@@ -1,4 +1,3 @@
-import { Prisma } from '@prisma/client/extension'
 import { has_nullish, int2str } from '../utils.js'
 
 /**
@@ -10,7 +9,7 @@ import { has_nullish, int2str } from '../utils.js'
  * @returns {Promise<import('$types/create.d.ts').createChildResult<T, A>>}
  */
 export default async function ({ node, data, ...args }) {
-	const ctx = Prisma.getExtensionContext(this)
+	const ctx = this
 
 	/** @type {string} */
 	let path = node?.path

--- a/packages/prisma-extension-bark/src/create/create-root.js
+++ b/packages/prisma-extension-bark/src/create/create-root.js
@@ -1,4 +1,3 @@
-import { Prisma } from '@prisma/client/extension'
 import { increment_path, int2str } from '../utils.js'
 
 /**
@@ -10,7 +9,7 @@ import { increment_path, int2str } from '../utils.js'
  * @returns {Promise<import('$types/create.d.ts').createRootResult<T, A>>}
  */
 export default async function ({ data, ...args }) {
-	const ctx = Prisma.getExtensionContext(this)
+	const ctx = this
 
 	const last_root = await ctx.findLastRoot({ select: {
 		path: true

--- a/packages/prisma-extension-bark/src/create/create-sibling.js
+++ b/packages/prisma-extension-bark/src/create/create-sibling.js
@@ -1,4 +1,3 @@
-import { Prisma } from '@prisma/client/extension'
 import { has_nullish, increment_path, path_from_depth } from '../utils.js'
 
 /**
@@ -10,7 +9,7 @@ import { has_nullish, increment_path, path_from_depth } from '../utils.js'
  * @returns {Promise<import('$types/create.d.ts').createChildResult<T, A>>}
  */
 export default async function ({ node, data, ...args }) {
-	const ctx = Prisma.getExtensionContext(this)
+	const ctx = this
 
 	/** @type {string} */
 	let path = node?.path

--- a/packages/prisma-extension-bark/src/delete/delete-many-nodes.js
+++ b/packages/prisma-extension-bark/src/delete/delete-many-nodes.js
@@ -1,4 +1,3 @@
-import { Prisma } from '@prisma/client/extension'
 import { path_from_depth } from '../utils.js'
 import { STEP_LENGTH } from '../consts.js'
 
@@ -11,7 +10,7 @@ import { STEP_LENGTH } from '../consts.js'
  * @returns {Promise<import('$types/delete.d.ts').deleteManyNodesResult<T, A>>}
  */
 export default async function ({ where }) {
-	const ctx = Prisma.getExtensionContext(this)
+	const ctx = this
 
 	const targets = await ctx.findMany({
 		where,

--- a/packages/prisma-extension-bark/src/delete/delete-node.js
+++ b/packages/prisma-extension-bark/src/delete/delete-node.js
@@ -1,4 +1,3 @@
-import { Prisma } from '@prisma/client/extension'
 import { has_nullish, path_from_depth } from '../utils.js'
 
 /**
@@ -10,7 +9,7 @@ import { has_nullish, path_from_depth } from '../utils.js'
  * @returns {Promise<import('$types/delete.d.ts').deleteNodeResult<T, A>>}
  */
 export default async function ({ node }) {
-	const ctx = Prisma.getExtensionContext(this)
+	const ctx = this
 
 	/** @type {string} */
 	let path = node?.path

--- a/packages/prisma-extension-bark/src/find/find-ancestors.js
+++ b/packages/prisma-extension-bark/src/find/find-ancestors.js
@@ -1,4 +1,3 @@
-import { Prisma } from '@prisma/client/extension'
 import { default_order_by } from '../consts.js'
 import { has_nullish, merge_where_args } from '../utils.js'
 
@@ -11,7 +10,7 @@ import { has_nullish, merge_where_args } from '../utils.js'
  * @returns {Promise<import('$types/find.d.ts').findAncestorsResult<T, A>>}
  */
 export default async function ({ node, where, orderBy = default_order_by, ...args }) {
-	const ctx = Prisma.getExtensionContext(this)
+	const ctx = this
 
 	/** @type {string} */
 	let path = node?.path

--- a/packages/prisma-extension-bark/src/find/find-children.js
+++ b/packages/prisma-extension-bark/src/find/find-children.js
@@ -1,4 +1,3 @@
-import { Prisma } from '@prisma/client/extension'
 import { default_order_by, max_segment, min_segment } from '../consts.js'
 import { has_nullish, merge_where_args } from '../utils.js'
 
@@ -11,7 +10,7 @@ import { has_nullish, merge_where_args } from '../utils.js'
  * @returns {Promise<import('$types/find.d.ts').findChildrenResult<T, A>>}
  */
 export default async function ({ node, orderBy = default_order_by, where, ...args }) {
-	const ctx = Prisma.getExtensionContext(this)
+	const ctx = this
 
 	/** @type {string} */
 	let path = node?.path

--- a/packages/prisma-extension-bark/src/find/find-descendants.js
+++ b/packages/prisma-extension-bark/src/find/find-descendants.js
@@ -1,4 +1,3 @@
-import { Prisma } from '@prisma/client/extension'
 import { default_order_by } from '../consts.js'
 import { has_nullish, merge_where_args } from '../utils.js'
 
@@ -11,7 +10,7 @@ import { has_nullish, merge_where_args } from '../utils.js'
  * @returns {Promise<import('$types/find.d.ts').findDescendantsResult<T, A>>}
  */
 export default async function ({ node, where, orderBy = default_order_by, ...args }) {
-	const ctx = Prisma.getExtensionContext(this)
+	const ctx = this
 
 	/** @type {string} */
 	let path = node?.path

--- a/packages/prisma-extension-bark/src/find/find-last-root.js
+++ b/packages/prisma-extension-bark/src/find/find-last-root.js
@@ -1,4 +1,3 @@
-import { Prisma } from '@prisma/client/extension'
 import { merge_where_args } from '../utils.js'
 
 
@@ -11,7 +10,7 @@ import { merge_where_args } from '../utils.js'
  * @returns {Promise<import('$types/find.d.ts').findLastRootNodeResult<T, A>>}
  */
 export default async function (args) {
-	const ctx = Prisma.getExtensionContext(this)
+	const ctx = this
 
 	return ctx.findFirst({
 		where: merge_where_args({

--- a/packages/prisma-extension-bark/src/find/find-parent.js
+++ b/packages/prisma-extension-bark/src/find/find-parent.js
@@ -1,4 +1,3 @@
-import { Prisma } from '@prisma/client/extension'
 import { has_nullish, merge_where_args, path_from_depth } from '../utils.js'
 
 /**
@@ -10,7 +9,7 @@ import { has_nullish, merge_where_args, path_from_depth } from '../utils.js'
  * @returns {Promise<import('$types/find.d.ts').findParentResult<T, A>>}
  */
 export default async function ({ node, where, ...args }) {
-	const ctx = Prisma.getExtensionContext(this)
+	const ctx = this
 
 	/** @type {string} */
 	let path = node?.path

--- a/packages/prisma-extension-bark/src/find/find-siblings.js
+++ b/packages/prisma-extension-bark/src/find/find-siblings.js
@@ -1,4 +1,3 @@
-import { Prisma } from '@prisma/client/extension'
 import { default_order_by, max_segment, min_segment } from '../consts.js'
 import { has_nullish, merge_where_args, path_from_depth } from '../utils.js'
 
@@ -11,7 +10,7 @@ import { has_nullish, merge_where_args, path_from_depth } from '../utils.js'
  * @returns {Promise<import('$types/find.d.ts').findSiblingsResult<T, A>>}
  */
 export default async function ({ node, where, orderBy = default_order_by, ...args }) {
-	const ctx = Prisma.getExtensionContext(this)
+	const ctx = this
 
 	/** @type {string} */
 	let path = node?.path

--- a/packages/prisma-extension-bark/src/index.js
+++ b/packages/prisma-extension-bark/src/index.js
@@ -1,5 +1,3 @@
-import { Prisma } from '@prisma/client/extension'
-
 import * as find from './find/index.js'
 import * as create from './create/index.js'
 import * as deletes from './delete/index.js'
@@ -7,10 +5,10 @@ import * as operations from './operations/index.js'
 
 /**
  * Initialize Bark as Prisma Extension
-*
-* @type {import('$types/index.d.ts').withBark}
-*/
-export const withBark = (args) => Prisma.defineExtension(function (client) {
+ *
+ * @type {import('$types/index.d.ts').withBark}
+ */
+export const withBark = (args) => (Prisma) => Prisma.defineExtension(function (client) {
 	const extensionMethods = {
 		...find,
 		...create,

--- a/packages/prisma-extension-bark/src/operations/move.js
+++ b/packages/prisma-extension-bark/src/operations/move.js
@@ -1,4 +1,3 @@
-import { Prisma } from '@prisma/client/extension'
 import { has_nullish, increment_path, int2str, last_position_in_path, path_from_depth } from '../utils.js'
 
 /**
@@ -10,7 +9,7 @@ import { has_nullish, increment_path, int2str, last_position_in_path, path_from_
  * @returns {Promise<import('$types/operations.d.ts').moveResult>}
  */
 export default async function ({ node, position, referenceNode }) {
-	const ctx = Prisma.getExtensionContext(this)
+	const ctx = this
 
 	let original_node = node
 	let rn_node = referenceNode
@@ -329,7 +328,6 @@ export default async function ({ node, position, referenceNode }) {
 	 * @param {number} opts.new_depth
 	 */
 	async function update_node_and_descendants({ old_path, new_path, new_depth }) {
-		/** @type {Promise<import('@prisma/client/extension').Prisma.PrismaPromise<any>> | any[]}*/
 		const queue = []
 
 		queue.push(ctx.update({

--- a/packages/prisma-extension-bark/test/custom-prisma-path.test.js
+++ b/packages/prisma-extension-bark/test/custom-prisma-path.test.js
@@ -1,0 +1,176 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { PrismaClient, Prisma } from '@prisma/client'
+import { withBark } from '../src/index.js'
+
+describe('Custom Prisma Path Integration', () => {
+  let prisma
+
+  beforeAll(() => {
+    // Test that withBark works with Prisma namespace parameter
+    prisma = new PrismaClient().$extends(
+      withBark({ modelNames: ['node'] })(Prisma)
+    )
+  })
+
+  it('should initialize extension with Prisma namespace parameter', () => {
+    expect(prisma).toBeDefined()
+    expect(prisma.node.createRoot).toBeDefined()
+    expect(prisma.node.createChild).toBeDefined()
+    expect(prisma.node.findChildren).toBeDefined()
+  })
+
+  it('should create root node using custom Prisma path', async () => {
+    const root = await prisma.node.createRoot({
+      data: { name: 'Custom Path Root' }
+    })
+
+    expect(root).toMatchObject({
+      name: 'Custom Path Root',
+      path: expect.stringMatching(/^[0-9A-Z]{4}$/),
+      depth: 1,
+      numchild: 0
+    })
+  })
+
+  it('should handle all CRUD operations with custom path', async () => {
+    // Create a root
+    const root = await prisma.node.createRoot({
+      data: { name: 'Test Root' }
+    })
+
+    // Create a child
+    const child = await prisma.node.createChild({
+      node: { id: root.id },
+      data: { name: 'Test Child' }
+    })
+
+    expect(child.path.startsWith(root.path)).toBe(true)
+    expect(child.depth).toBe(root.depth + 1)
+
+    // Find children
+    const children = await prisma.node.findChildren({
+      node: { id: root.id }
+    })
+
+    expect(children).toHaveLength(1)
+    expect(children[0].id).toBe(child.id)
+
+    // Create sibling
+    const sibling = await prisma.node.createSibling({
+      node: { id: child.id },
+      data: { name: 'Test Sibling' }
+    })
+
+    expect(sibling.depth).toBe(child.depth)
+    expect(sibling.path).not.toBe(child.path)
+
+    // Find parent
+    const parent = await prisma.node.findParent({
+      node: { id: child.id }
+    })
+
+    expect(parent.id).toBe(root.id)
+
+    // Delete node
+    const deleted = await prisma.node.deleteNode({
+      node: { id: child.id }
+    })
+
+    expect(deleted.count).toBeGreaterThan(0)
+  })
+
+  it('should work with transactions', { timeout: 10000 }, async () => {
+    const result = await prisma.$transaction(async (tx) => {
+      const root = await tx.node.createRoot({
+        data: { name: 'Transaction Root' }
+      })
+
+      const child1 = await tx.node.createChild({
+        node: { id: root.id },
+        data: { name: 'Transaction Child 1' }
+      })
+
+      const child2 = await tx.node.createChild({
+        node: { id: root.id },
+        data: { name: 'Transaction Child 2' }
+      })
+
+      return { root, child1, child2 }
+    })
+
+    expect(result.root).toBeDefined()
+    expect(result.child1.path.startsWith(result.root.path)).toBe(true)
+    expect(result.child2.path.startsWith(result.root.path)).toBe(true)
+    expect(result.child1.path).not.toBe(result.child2.path)
+  })
+
+  it('should handle complex tree operations', async () => {
+    // Create a tree structure
+    const root = await prisma.node.createRoot({
+      data: { name: 'Company' }
+    })
+
+    const dept1 = await prisma.node.createChild({
+      node: { id: root.id },
+      data: { name: 'Engineering' }
+    })
+
+    const dept2 = await prisma.node.createChild({
+      node: { id: root.id },
+      data: { name: 'Marketing' }
+    })
+
+    const team1 = await prisma.node.createChild({
+      node: { id: dept1.id },
+      data: { name: 'Backend Team' }
+    })
+
+    const team2 = await prisma.node.createChild({
+      node: { id: dept1.id },
+      data: { name: 'Frontend Team' }
+    })
+
+    // Find all descendants of Engineering
+    const engDescendants = await prisma.node.findDescendants({
+      node: { id: dept1.id }
+    })
+
+    expect(engDescendants).toHaveLength(2)
+    expect(engDescendants.map(n => n.name)).toContain('Backend Team')
+    expect(engDescendants.map(n => n.name)).toContain('Frontend Team')
+
+    // Find ancestors of Backend Team
+    const ancestors = await prisma.node.findAncestors({
+      node: { id: team1.id }
+    })
+
+    expect(ancestors).toHaveLength(2)
+    expect(ancestors.map(n => n.name)).toContain('Company')
+    expect(ancestors.map(n => n.name)).toContain('Engineering')
+
+    // Move Backend Team to Marketing
+    await prisma.node.move({
+      node: { id: team1.id },
+      referenceNode: { id: dept2.id },
+      position: 'child'
+    })
+
+    // Verify move
+    const movedTeam = await prisma.node.findUnique({
+      where: { id: team1.id }
+    })
+
+    const movedTeamParent = await prisma.node.findParent({
+      node: { id: team1.id }
+    })
+
+    expect(movedTeamParent?.id).toBe(dept2.id)
+    expect(movedTeamParent?.name).toBe('Marketing')
+  })
+
+  afterAll(async () => {
+    // Clean up test data
+    await prisma.node.deleteMany()
+    await prisma.$disconnect()
+  })
+})

--- a/packages/prisma-extension-bark/test/prisma-compatibility.test.js
+++ b/packages/prisma-extension-bark/test/prisma-compatibility.test.js
@@ -1,0 +1,407 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { PrismaClient, Prisma } from '@prisma/client'
+import { withBark } from '../src/index.js'
+
+describe('Prisma Standard Functions Compatibility', () => {
+  let prisma
+  let testNodes = []
+
+  beforeAll(() => {
+    // Initialize Prisma with Bark extension
+    prisma = new PrismaClient().$extends(
+      withBark({ modelNames: ['node'] })(Prisma)
+    )
+  })
+
+  afterAll(async () => {
+    // Clean up test data
+    if (testNodes.length > 0) {
+      await prisma.node.deleteMany({
+        where: {
+          id: { in: testNodes.map(n => n.id) }
+        }
+      })
+    }
+    await prisma.$disconnect()
+  })
+
+  describe('Standard Prisma CRUD Operations', () => {
+    it('should support standard create operation', async () => {
+      const node = await prisma.node.create({
+        data: {
+          name: 'Standard Create Test',
+          path: 'TEST0001',
+          depth: 1,
+          numchild: 0
+        }
+      })
+
+      expect(node).toMatchObject({
+        name: 'Standard Create Test',
+        path: 'TEST0001',
+        depth: 1,
+        numchild: 0
+      })
+
+      testNodes.push(node)
+    })
+
+    it('should support findUnique operation', async () => {
+      // Create a node first
+      const created = await prisma.node.create({
+        data: {
+          name: 'Find Unique Test',
+          path: 'TEST0002',
+          depth: 1,
+          numchild: 0
+        }
+      })
+      testNodes.push(created)
+
+      // Find it using findUnique
+      const found = await prisma.node.findUnique({
+        where: { id: created.id }
+      })
+
+      expect(found).toMatchObject({
+        id: created.id,
+        name: 'Find Unique Test',
+        path: 'TEST0002'
+      })
+    })
+
+    it('should support findFirst operation', async () => {
+      const created = await prisma.node.create({
+        data: {
+          name: 'Find First Test',
+          path: 'TEST0003',
+          depth: 2,
+          numchild: 0
+        }
+      })
+      testNodes.push(created)
+
+      const found = await prisma.node.findFirst({
+        where: { 
+          name: 'Find First Test',
+          depth: 2
+        }
+      })
+
+      expect(found?.id).toBe(created.id)
+    })
+
+    it('should support findMany operation', async () => {
+      // Create multiple nodes
+      const nodes = await Promise.all([
+        prisma.node.create({
+          data: {
+            name: 'Find Many 1',
+            path: 'TEST0004',
+            depth: 3,
+            numchild: 0
+          }
+        }),
+        prisma.node.create({
+          data: {
+            name: 'Find Many 2',
+            path: 'TEST0005',
+            depth: 3,
+            numchild: 0
+          }
+        })
+      ])
+      testNodes.push(...nodes)
+
+      const found = await prisma.node.findMany({
+        where: { depth: 3 },
+        orderBy: { path: 'asc' }
+      })
+
+      expect(found.length).toBeGreaterThanOrEqual(2)
+      expect(found.some(n => n.name === 'Find Many 1')).toBe(true)
+      expect(found.some(n => n.name === 'Find Many 2')).toBe(true)
+    })
+
+    it('should support update operation', async () => {
+      const created = await prisma.node.create({
+        data: {
+          name: 'Update Test',
+          path: 'TEST0006',
+          depth: 1,
+          numchild: 0
+        }
+      })
+      testNodes.push(created)
+
+      const updated = await prisma.node.update({
+        where: { id: created.id },
+        data: { name: 'Updated Name' }
+      })
+
+      expect(updated.name).toBe('Updated Name')
+      expect(updated.id).toBe(created.id)
+    })
+
+    it('should support updateMany operation', async () => {
+      const nodes = await Promise.all([
+        prisma.node.create({
+          data: {
+            name: 'Update Many Test',
+            path: 'TEST0007',
+            depth: 4,
+            numchild: 0
+          }
+        }),
+        prisma.node.create({
+          data: {
+            name: 'Update Many Test',
+            path: 'TEST0008',
+            depth: 4,
+            numchild: 0
+          }
+        })
+      ])
+      testNodes.push(...nodes)
+
+      const result = await prisma.node.updateMany({
+        where: { 
+          name: 'Update Many Test',
+          depth: 4
+        },
+        data: { name: 'Bulk Updated' }
+      })
+
+      expect(result.count).toBeGreaterThanOrEqual(2)
+    })
+
+    it('should support delete operation', async () => {
+      const created = await prisma.node.create({
+        data: {
+          name: 'Delete Test',
+          path: 'TEST0009',
+          depth: 1,
+          numchild: 0
+        }
+      })
+
+      const deleted = await prisma.node.delete({
+        where: { id: created.id }
+      })
+
+      expect(deleted.id).toBe(created.id)
+
+      // Verify it's deleted
+      const found = await prisma.node.findUnique({
+        where: { id: created.id }
+      })
+      expect(found).toBeNull()
+    })
+
+    it('should support deleteMany operation', async () => {
+      const nodes = await Promise.all([
+        prisma.node.create({
+          data: {
+            name: 'Delete Many Test',
+            path: 'TEST0010',
+            depth: 5,
+            numchild: 0
+          }
+        }),
+        prisma.node.create({
+          data: {
+            name: 'Delete Many Test',
+            path: 'TEST0011',
+            depth: 5,
+            numchild: 0
+          }
+        })
+      ])
+
+      const result = await prisma.node.deleteMany({
+        where: { 
+          name: 'Delete Many Test',
+          depth: 5
+        }
+      })
+
+      expect(result.count).toBeGreaterThanOrEqual(2)
+    })
+
+    it('should support count operation', async () => {
+      const created = await prisma.node.create({
+        data: {
+          name: 'Count Test',
+          path: 'TEST0012',
+          depth: 6,
+          numchild: 0
+        }
+      })
+      testNodes.push(created)
+
+      const count = await prisma.node.count({
+        where: { depth: 6 }
+      })
+
+      expect(count).toBeGreaterThanOrEqual(1)
+    })
+
+    it('should support aggregate operations', async () => {
+      const created = await prisma.node.create({
+        data: {
+          name: 'Aggregate Test',
+          path: 'TEST0013',
+          depth: 7,
+          numchild: 3
+        }
+      })
+      testNodes.push(created)
+
+      const result = await prisma.node.aggregate({
+        where: { depth: 7 },
+        _avg: { numchild: true },
+        _max: { numchild: true },
+        _min: { numchild: true }
+      })
+
+      expect(result._max.numchild).toBeGreaterThanOrEqual(3)
+    })
+  })
+
+  describe('Prisma and Bark Methods Together', () => {
+    it('should allow using Prisma and Bark methods on same model', async () => {
+      // Use Bark method to create a root
+      const timestamp = Date.now()
+      const root = await prisma.node.createRoot({
+        data: { name: `Mixed Methods Root ${timestamp}` }
+      })
+      testNodes.push(root)
+
+      // Use standard Prisma to find it
+      const found = await prisma.node.findUnique({
+        where: { id: root.id }
+      })
+
+      expect(found?.name).toBe('Mixed Methods Root')
+
+      // Use Bark method to create a child
+      const child = await prisma.node.createChild({
+        node: { id: root.id },
+        data: { name: 'Mixed Methods Child' }
+      })
+      testNodes.push(child)
+
+      // Use standard Prisma to update it
+      const updated = await prisma.node.update({
+        where: { id: child.id },
+        data: { name: 'Updated Child Name' }
+      })
+
+      expect(updated.name).toBe('Updated Child Name')
+
+      // Use Bark method to find children
+      const children = await prisma.node.findChildren({
+        node: { id: root.id }
+      })
+
+      expect(children).toHaveLength(1)
+      expect(children[0].name).toBe('Updated Child Name')
+    })
+
+    it('should support transactions with both Prisma and Bark methods', async () => {
+      const result = await prisma.$transaction(async (tx) => {
+        // Bark method
+        const root = await tx.node.createRoot({
+          data: { name: 'Transaction Mixed Root' }
+        })
+
+        // Standard Prisma method
+        const updated = await tx.node.update({
+          where: { id: root.id },
+          data: { name: 'Transaction Updated Root' }
+        })
+
+        // Bark method
+        const child = await tx.node.createChild({
+          node: { id: root.id },
+          data: { name: 'Transaction Child' }
+        })
+
+        // Standard Prisma method
+        const count = await tx.node.count({
+          where: {
+            path: { startsWith: root.path }
+          }
+        })
+
+        return { root: updated, child, count }
+      })
+
+      expect(result.root.name).toBe('Transaction Updated Root')
+      expect(result.child.name).toBe('Transaction Child')
+      expect(result.count).toBe(2) // root + child
+
+      // Clean up
+      testNodes.push(result.root, result.child)
+    })
+
+    it('should maintain select and include functionality', async () => {
+      const root = await prisma.node.createRoot({
+        data: { name: 'Select Test Root' },
+        select: {
+          id: true,
+          name: true,
+          path: true
+        }
+      })
+      testNodes.push(root)
+
+      expect(root).toHaveProperty('id')
+      expect(root).toHaveProperty('name')
+      expect(root).toHaveProperty('path')
+      // Should not have other fields when using select
+      expect(root).not.toHaveProperty('created_at')
+
+      // Standard Prisma with select
+      const found = await prisma.node.findUnique({
+        where: { id: root.id },
+        select: {
+          name: true,
+          depth: true
+        }
+      })
+
+      expect(found).toHaveProperty('name')
+      expect(found).toHaveProperty('depth')
+      expect(found).not.toHaveProperty('id')
+    })
+
+    it('should support where conditions with Bark methods', async () => {
+      const root = await prisma.node.createRoot({
+        data: { name: 'Where Test Root' }
+      })
+      testNodes.push(root)
+
+      const children = await Promise.all([
+        prisma.node.createChild({
+          node: { id: root.id },
+          data: { name: 'Active Child' }
+        }),
+        prisma.node.createChild({
+          node: { id: root.id },
+          data: { name: 'Inactive Child' }
+        })
+      ])
+      testNodes.push(...children)
+
+      // Find children with additional where conditions
+      const activeChildren = await prisma.node.findChildren({
+        node: { id: root.id },
+        where: { name: { contains: 'Active' } }
+      })
+
+      expect(activeChildren).toHaveLength(1)
+      expect(activeChildren[0].name).toBe('Active Child')
+    })
+  })
+})

--- a/packages/prisma-extension-bark/test/prisma-namespace.test.js
+++ b/packages/prisma-extension-bark/test/prisma-namespace.test.js
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest'
+import { PrismaClient, Prisma } from '@prisma/client'
+import { withBark } from '../src/index.js'
+
+describe('Prisma Namespace Parameter', () => {
+  it('should accept Prisma namespace as parameter', () => {
+    // This is the main test - verifying the API works
+    const extendedClient = new PrismaClient().$extends(
+      withBark({ modelNames: ['node'] })(Prisma)
+    )
+
+    // Verify all methods are available
+    expect(typeof extendedClient.node.createRoot).toBe('function')
+    expect(typeof extendedClient.node.createChild).toBe('function')
+    expect(typeof extendedClient.node.createSibling).toBe('function')
+    expect(typeof extendedClient.node.findParent).toBe('function')
+    expect(typeof extendedClient.node.findChildren).toBe('function')
+    expect(typeof extendedClient.node.findSiblings).toBe('function')
+    expect(typeof extendedClient.node.findAncestors).toBe('function')
+    expect(typeof extendedClient.node.findDescendants).toBe('function')
+    expect(typeof extendedClient.node.findLastRoot).toBe('function')
+    expect(typeof extendedClient.node.deleteNode).toBe('function')
+    expect(typeof extendedClient.node.deleteManyNodes).toBe('function')
+    expect(typeof extendedClient.node.move).toBe('function')
+
+    extendedClient.$disconnect()
+  })
+
+  it('should work with basic operations', async () => {
+    const prisma = new PrismaClient().$extends(
+      withBark({ modelNames: ['node'] })(Prisma)
+    )
+
+    try {
+      // Create a unique root for this test
+      const testId = `test-${Date.now()}`
+      const root = await prisma.node.createRoot({
+        data: { name: testId }
+      })
+
+      expect(root).toMatchObject({
+        name: testId,
+        path: expect.any(String),
+        depth: 1,
+        numchild: 0
+      })
+
+      // Clean up
+      await prisma.node.delete({
+        where: { id: root.id }
+      })
+    } finally {
+      await prisma.$disconnect()
+    }
+  })
+
+  it('should maintain backwards compatibility', () => {
+    // The old API (if it existed) would have been:
+    // const prisma = new PrismaClient().$extends(withBark({ modelNames: ['node'] }))
+    
+    // The new API requires passing Prisma:
+    const prisma = new PrismaClient().$extends(
+      withBark({ modelNames: ['node'] })(Prisma)
+    )
+
+    expect(prisma.node).toBeDefined()
+    prisma.$disconnect()
+  })
+})

--- a/packages/prisma-extension-bark/test/prisma-standard-ops.test.js
+++ b/packages/prisma-extension-bark/test/prisma-standard-ops.test.js
@@ -1,0 +1,298 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { PrismaClient, Prisma } from '@prisma/client'
+import { withBark } from '../src/index.js'
+
+describe('Prisma Standard Operations Compatibility', () => {
+  let prisma
+  let testNodeIds = []
+
+  beforeEach(() => {
+    // Fresh client for each test
+    prisma = new PrismaClient().$extends(
+      withBark({ modelNames: ['node'] })(Prisma)
+    )
+    testNodeIds = []
+  })
+
+  afterEach(async () => {
+    // Clean up any test nodes created
+    if (testNodeIds.length > 0) {
+      await prisma.node.deleteMany({
+        where: { id: { in: testNodeIds } }
+      })
+    }
+    await prisma.$disconnect()
+  })
+
+  it('should support findMany with ordering and filtering', async () => {
+    // Create test nodes with unique paths
+    const timestamp = Date.now()
+    const nodes = await Promise.all([
+      prisma.node.create({
+        data: {
+          name: 'Test Node A',
+          path: `A${timestamp}01`,
+          depth: 2,
+          numchild: 0
+        }
+      }),
+      prisma.node.create({
+        data: {
+          name: 'Test Node B',
+          path: `A${timestamp}02`,
+          depth: 2,
+          numchild: 0
+        }
+      }),
+      prisma.node.create({
+        data: {
+          name: 'Test Node C',
+          path: `A${timestamp}03`,
+          depth: 3,
+          numchild: 0
+        }
+      })
+    ])
+    testNodeIds.push(...nodes.map(n => n.id))
+
+    // Test findMany with where and orderBy
+    const found = await prisma.node.findMany({
+      where: { 
+        depth: 2,
+        path: { startsWith: `A${timestamp}` }
+      },
+      orderBy: { path: 'desc' }
+    })
+
+    expect(found).toHaveLength(2)
+    expect(found[0].name).toBe('Test Node B')
+    expect(found[1].name).toBe('Test Node A')
+  })
+
+  it('should support findUnique with select', async () => {
+    const timestamp = Date.now()
+    const node = await prisma.node.create({
+      data: {
+        name: 'Select Test',
+        path: `SEL${timestamp}`,
+        depth: 1,
+        numchild: 0
+      }
+    })
+    testNodeIds.push(node.id)
+
+    const selected = await prisma.node.findUnique({
+      where: { id: node.id },
+      select: {
+        name: true,
+        path: true
+      }
+    })
+
+    expect(selected).toEqual({
+      name: 'Select Test',
+      path: `SEL${timestamp}`
+    })
+    expect(selected.id).toBeUndefined()
+    expect(selected.depth).toBeUndefined()
+  })
+
+  it('should support upsert operation', async () => {
+    const timestamp = Date.now()
+    const uniquePath = `UPS${timestamp}`
+
+    // First upsert - should create
+    const created = await prisma.node.upsert({
+      where: { path: uniquePath },
+      update: { name: 'Updated' },
+      create: {
+        name: 'Created',
+        path: uniquePath,
+        depth: 1,
+        numchild: 0
+      }
+    })
+
+    expect(created.name).toBe('Created')
+    testNodeIds.push(created.id)
+
+    // Second upsert - should update
+    const updated = await prisma.node.upsert({
+      where: { path: uniquePath },
+      update: { name: 'Updated' },
+      create: {
+        name: 'Should not create',
+        path: uniquePath,
+        depth: 1,
+        numchild: 0
+      }
+    })
+
+    expect(updated.id).toBe(created.id)
+    expect(updated.name).toBe('Updated')
+  })
+
+  it('should work with Bark methods in the same query chain', async () => {
+    // First, use standard Prisma to check if any roots exist
+    const existingCount = await prisma.node.count({
+      where: { depth: 1 }
+    })
+
+    // Create a root using Bark
+    const root = await prisma.node.createRoot({
+      data: { name: `Compatibility Test Root ${Date.now()}` }
+    })
+    testNodeIds.push(root.id)
+
+    // Verify count increased
+    const newCount = await prisma.node.count({
+      where: { depth: 1 }
+    })
+    expect(newCount).toBe(existingCount + 1)
+
+    // Create children using Bark
+    const child1 = await prisma.node.createChild({
+      node: { id: root.id },
+      data: { name: 'Child 1' }
+    })
+    const child2 = await prisma.node.createChild({
+      node: { id: root.id },
+      data: { name: 'Child 2' }
+    })
+    testNodeIds.push(child1.id, child2.id)
+
+    // Use standard Prisma to find all children
+    const children = await prisma.node.findMany({
+      where: {
+        path: {
+          startsWith: root.path,
+          not: root.path
+        }
+      },
+      orderBy: { path: 'asc' }
+    })
+
+    expect(children).toHaveLength(2)
+    expect(children[0].name).toBe('Child 1')
+    expect(children[1].name).toBe('Child 2')
+  })
+
+  it('should support groupBy operations', async () => {
+    const timestamp = Date.now()
+    
+    // Create nodes at different depths
+    const nodes = await Promise.all([
+      prisma.node.create({
+        data: { name: 'Group 1', path: `G${timestamp}01`, depth: 1, numchild: 2 }
+      }),
+      prisma.node.create({
+        data: { name: 'Group 2', path: `G${timestamp}02`, depth: 1, numchild: 3 }
+      }),
+      prisma.node.create({
+        data: { name: 'Group 3', path: `G${timestamp}03`, depth: 2, numchild: 0 }
+      })
+    ])
+    testNodeIds.push(...nodes.map(n => n.id))
+
+    const grouped = await prisma.node.groupBy({
+      by: ['depth'],
+      where: {
+        path: { startsWith: `G${timestamp}` }
+      },
+      _count: true,
+      _sum: { numchild: true },
+      _avg: { numchild: true }
+    })
+
+    const depth1Group = grouped.find(g => g.depth === 1)
+    expect(depth1Group?._count).toBe(2)
+    expect(depth1Group?._sum.numchild).toBe(5)
+    expect(depth1Group?._avg.numchild).toBe(2.5)
+  })
+
+  it('should support transactions mixing Bark and Prisma operations', async () => {
+    const result = await prisma.$transaction(async (tx) => {
+      // Create root with Bark
+      const root = await tx.node.createRoot({
+        data: { name: `Transaction Test ${Date.now()}` }
+      })
+
+      // Update with standard Prisma
+      const updatedRoot = await tx.node.update({
+        where: { id: root.id },
+        data: { name: 'Updated Root Name' }
+      })
+
+      // Create a child node using standard Prisma (not Bark)
+      const childPath = root.path + '0001'
+      const child1 = await tx.node.create({
+        data: {
+          name: 'TX Child 1',
+          path: childPath,
+          depth: root.depth + 1,
+          numchild: 0
+        }
+      })
+
+      // Update parent's numchild
+      await tx.node.update({
+        where: { id: root.id },
+        data: { numchild: 1 }
+      })
+
+      // Find with standard Prisma
+      const allNodes = await tx.node.findMany({
+        where: {
+          path: { startsWith: root.path }
+        },
+        orderBy: { path: 'asc' }
+      })
+
+      return { root: updatedRoot, child1, allNodes }
+    })
+
+    testNodeIds.push(result.root.id, result.child1.id)
+    expect(result.allNodes).toHaveLength(2)
+    expect(result.root.name).toBe('Updated Root Name')
+  })
+
+  it('should preserve all standard Prisma query capabilities', async () => {
+    const timestamp = Date.now()
+    
+    // Complex query with multiple conditions
+    const node = await prisma.node.create({
+      data: {
+        name: 'Complex Query Test',
+        path: `CQ${timestamp}`,
+        depth: 5,
+        numchild: 10
+      }
+    })
+    testNodeIds.push(node.id)
+
+    // Test various query operators
+    const found = await prisma.node.findFirst({
+      where: {
+        AND: [
+          { depth: { gte: 5 } },
+          { numchild: { lt: 20 } },
+          { path: { contains: timestamp.toString() } }
+        ]
+      }
+    })
+
+    expect(found?.id).toBe(node.id)
+
+    // Test NOT operator
+    const notFound = await prisma.node.findMany({
+      where: {
+        NOT: {
+          id: node.id
+        },
+        path: { startsWith: `CQ${timestamp}` }
+      }
+    })
+
+    expect(notFound).toHaveLength(0)
+  })
+})

--- a/packages/prisma-extension-bark/test/simple-type-test.ts
+++ b/packages/prisma-extension-bark/test/simple-type-test.ts
@@ -1,0 +1,20 @@
+// Simple test to verify the types work
+import { PrismaClient, Prisma } from '@prisma/client'
+import { withBark } from '../src/index.js'
+
+// This should work without 'as any'
+const prisma = new PrismaClient().$extends(
+  withBark({ modelNames: ['node'] })(Prisma)
+)
+
+// Test that the types are recognized
+const test = async () => {
+  // These should have proper TypeScript support
+  const root = await prisma.node.createRoot({
+    data: { name: 'Test' }
+  })
+  
+  console.log('Types work correctly:', root.id, root.path)
+}
+
+test()

--- a/packages/prisma-extension-bark/test/tsconfig.json
+++ b/packages/prisma-extension-bark/test/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+    "types": ["vitest/globals"],
+    "lib": ["ES2022"],
+    "baseUrl": "..",
+    "paths": {
+      "$types/*": ["./types/*"]
+    }
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/packages/prisma-extension-bark/test/typescript-integration.test.ts
+++ b/packages/prisma-extension-bark/test/typescript-integration.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest'
+import { PrismaClient, Prisma } from '@prisma/client'
+import { withBark } from '../src/index.js'
+
+// This test file verifies TypeScript integration works without 'as any'
+describe('TypeScript Integration', () => {
+  it('should compile without type errors', () => {
+    // This should compile without needing 'as any'
+    const prisma = new PrismaClient().$extends(
+      withBark({ modelNames: ['node'] })(Prisma)
+    )
+
+    // Verify the extended client has proper types
+    expect(prisma.node.createRoot).toBeDefined()
+    expect(prisma.node.createChild).toBeDefined()
+    expect(prisma.node.createSibling).toBeDefined()
+    expect(prisma.node.findParent).toBeDefined()
+    expect(prisma.node.findChildren).toBeDefined()
+    expect(prisma.node.findSiblings).toBeDefined()
+    expect(prisma.node.findAncestors).toBeDefined()
+    expect(prisma.node.findDescendants).toBeDefined()
+    expect(prisma.node.findLastRoot).toBeDefined()
+    expect(prisma.node.deleteNode).toBeDefined()
+    expect(prisma.node.deleteManyNodes).toBeDefined()
+    expect(prisma.node.move).toBeDefined()
+  })
+
+  it('should maintain type safety for method arguments', async () => {
+    const prisma = new PrismaClient().$extends(
+      withBark({ modelNames: ['node'] })(Prisma)
+    )
+
+    // TypeScript should enforce correct argument types
+    const root = await prisma.node.createRoot({
+      data: { name: 'TypeSafe Root' }
+    })
+
+    // This should have proper types for the result
+    expect(root.id).toBeDefined()
+    expect(root.path).toBeDefined()
+    expect(root.depth).toBe(1)
+    expect(root.numchild).toBe(0)
+    expect(root.name).toBe('TypeSafe Root')
+
+    // Method chaining should work with proper types
+    const children = await prisma.node
+      .findChildren({
+        node: { id: root.id },
+        select: { id: true, name: true }
+      })
+
+    // TypeScript should know the shape of children based on select
+    if (children.length > 0) {
+      expect(children[0].id).toBeDefined()
+      expect(children[0].name).toBeDefined()
+    }
+
+    await prisma.$disconnect()
+  })
+
+  it('should work with different Prisma client configurations', () => {
+    // Test with custom Prisma client configuration
+    const customPrisma = new PrismaClient({
+      log: ['query'],
+    }).$extends(
+      withBark({ modelNames: ['node'] })(Prisma)
+    )
+
+    expect(customPrisma.node.createRoot).toBeDefined()
+    customPrisma.$disconnect()
+  })
+
+  it('should support multiple model names', () => {
+    // Assuming we have multiple models that support bark
+    const multiModelPrisma = new PrismaClient().$extends(
+      withBark({ modelNames: ['node'] })(Prisma)
+    )
+
+    expect(multiModelPrisma.node).toBeDefined()
+    multiModelPrisma.$disconnect()
+  })
+})

--- a/packages/prisma-extension-bark/test/utilities/prisma.js
+++ b/packages/prisma-extension-bark/test/utilities/prisma.js
@@ -1,7 +1,9 @@
-import { PrismaClient } from '@prisma/client'
+import { PrismaClient, Prisma } from '@prisma/client'
 import { withBark } from '../../src/index.js'
 
-export const prisma = new PrismaClient().$extends(withBark({modelNames: ['node']}))
+export const prisma = new PrismaClient().$extends(
+  withBark({modelNames: ['node']})(Prisma)
+)
 
 export const get_root_node = async () => prisma.node.findUniqueOrThrow({where: { id: 1 } })
 export const get_home_node = async () => prisma.node.findUniqueOrThrow({ where: { id: 2 } })

--- a/packages/prisma-extension-bark/types/extension.d.ts
+++ b/packages/prisma-extension-bark/types/extension.d.ts
@@ -7,5 +7,5 @@ import { BarkMethods } from ".";
  * the `getExtensionContext` method exposes other ones too + "fields"
  * @deprecated
  */
-export type BarkExtensionContext<T> = BarkMethods & { name?: string | undefined; }
+export type BarkExtensionContext<T> = BarkMethods<any> & { name?: string | undefined; }
 

--- a/packages/prisma-extension-bark/types/index.d.ts
+++ b/packages/prisma-extension-bark/types/index.d.ts
@@ -1,4 +1,4 @@
-import PrismaDefault, { type Prisma } from "@prisma/client/scripts/default-index.d.ts";
+import type PrismaDefault from "@prisma/client/scripts/default-index.d.ts";
 import type { Types } from "@prisma/client/runtime/library.d.ts";
 import { PrismaModelProps } from "./prisma.d.ts";
 import { findAncestorsArgs, findChildrenArgs, findChildrenResult, findDescendantsArgs, findDescendantsResult, findLastRootNodeArgs, findLastRootNodeResult, findParentArgs, findParentResult, findSiblingsArgs, findSiblingsResult } from "./find.d.ts";
@@ -15,31 +15,31 @@ type BarkInitArgs = {
 	modelNames: PrismaModelProps[];
 }
 
-export type BarkFindMethods = {
-	findLastRoot<T, A>(this: T, args: findLastRootNodeArgs<T, A>): Prisma.PrismaPromise<findLastRootNodeResult<T, A>>;
-	findAncestors<T, A>(this: T, args: findAncestorsArgs<T, A>): Prisma.PrismaPromise<findAncestorsResult<T, A>>;
-	findDescendants<T, A>(this: T, args: findDescendantsArgs<T, A>): Prisma.PrismaPromise<findDescendantsResult<T, A>>;
-	findChildren<T, A>(this: T, args: findChildrenArgs<T, A>): Prisma.PrismaPromise<findChildrenResult<T, A>>;
-	findSiblings<T, A>(this: T, args: findSiblingsArgs<T, A>): Prisma.PrismaPromise<findSiblingsResult<T, A>>;
-	findParent<T, A>(this: T, args: findParentArgs<T, A>): Prisma.PrismaPromise<findParentResult<T, A>>;
+export type BarkFindMethods<PrismaPromise> = {
+	findLastRoot<T, A>(this: T, args: findLastRootNodeArgs<T, A>): PrismaPromise<findLastRootNodeResult<T, A>>;
+	findAncestors<T, A>(this: T, args: findAncestorsArgs<T, A>): PrismaPromise<findAncestorsResult<T, A>>;
+	findDescendants<T, A>(this: T, args: findDescendantsArgs<T, A>): PrismaPromise<findDescendantsResult<T, A>>;
+	findChildren<T, A>(this: T, args: findChildrenArgs<T, A>): PrismaPromise<findChildrenResult<T, A>>;
+	findSiblings<T, A>(this: T, args: findSiblingsArgs<T, A>): PrismaPromise<findSiblingsResult<T, A>>;
+	findParent<T, A>(this: T, args: findParentArgs<T, A>): PrismaPromise<findParentResult<T, A>>;
 }
 
-export type BarkCreateMethods = {
-	createChild<T, A>(this: T, args: createChildArgs<T, A>): Prisma.PrismaPromise<createChildResult<T, A>>;
-	createSibling<T, A>(this: T, args: createSiblingArgs<T, A>): Prisma.PrismaPromise<createSiblingResult<T, A>>;
-	createRoot<T, A>(this: T, args: createRootArgs<T, A>): Prisma.PrismaPromise<createRootResult<T, A>>;
+export type BarkCreateMethods<PrismaPromise> = {
+	createChild<T, A>(this: T, args: createChildArgs<T, A>): PrismaPromise<createChildResult<T, A>>;
+	createSibling<T, A>(this: T, args: createSiblingArgs<T, A>): PrismaPromise<createSiblingResult<T, A>>;
+	createRoot<T, A>(this: T, args: createRootArgs<T, A>): PrismaPromise<createRootResult<T, A>>;
 }
 
-export type BarkDeleteMethods = {
-	deleteNode<T, A>(this: T, args: deleteNodeArgs<T, A>): Prisma.PrismaPromise<deleteNodeResult<T, A>>;
-	deleteManyNodes<T, A>(this: T, args: deleteManyNodesArgs<T, A>): Prisma.PrismaPromise<deleteManyNodesResult<T, A>>;
+export type BarkDeleteMethods<PrismaPromise> = {
+	deleteNode<T, A>(this: T, args: deleteNodeArgs<T, A>): PrismaPromise<deleteNodeResult<T, A>>;
+	deleteManyNodes<T, A>(this: T, args: deleteManyNodesArgs<T, A>): PrismaPromise<deleteManyNodesResult<T, A>>;
 }
 
-export type BarkOperationsMethods = {
-	move<T, A>(this: T, args: moveArgs<T, A>): Prisma.PrismaPromise<moveResult>
+export type BarkOperationsMethods<PrismaPromise> = {
+	move<T, A>(this: T, args: moveArgs<T, A>): PrismaPromise<moveResult>
 }
 
-export type BarkMethods = BarkFindMethods & BarkCreateMethods & BarkDeleteMethods & BarkOperationsMethods
+export type BarkMethods<PrismaPromise = any> = BarkFindMethods<PrismaPromise> & BarkCreateMethods<PrismaPromise> & BarkDeleteMethods<PrismaPromise> & BarkOperationsMethods<PrismaPromise>
 
 /**
  * Extends Prisma Client with Bark
@@ -47,10 +47,14 @@ export type BarkMethods = BarkFindMethods & BarkCreateMethods & BarkDeleteMethod
  * Docs: {@link https://prisma-extension-bark.gitbook.io/docs/client-extension-api-reference#extend-a-prisma-client}
  *
  * @example
+ * import { PrismaClient, Prisma } from '../generated/client'
  * const xprisma = new PrismaClient().$extends(withBark({
  *  modelNames: ['node']
- * }))
+ * })(Prisma))
  */
-export declare function withBark<I extends BarkInitArgs>(args: I): (client: any) => PrismaDefault.PrismaClientExtends<Types.Extensions.InternalArgs<{}, {
-	readonly [K in (I['modelNames'] extends ReadonlyArray<infer U> ? U : never)]: BarkMethods
+export declare function withBark<I extends BarkInitArgs>(args: I): <P extends {
+	defineExtension: Function;
+	PrismaPromise: any;
+}>(Prisma: P) => (client: any) => PrismaDefault.PrismaClientExtends<Types.Extensions.InternalArgs<{}, {
+	readonly [K in (I['modelNames'] extends ReadonlyArray<infer U> ? U : never)]: BarkMethods<P['PrismaPromise']>
 }, {}, {}> & Types.Extensions.InternalArgs<{}, {}, {}, {}> & Types.Extensions.DefaultArgs>;

--- a/packages/prisma-extension-bark/types/index.d.ts
+++ b/packages/prisma-extension-bark/types/index.d.ts
@@ -53,8 +53,8 @@ export type BarkMethods<PrismaPromise = any> = BarkFindMethods<PrismaPromise> & 
  * })(Prisma))
  */
 export declare function withBark<I extends BarkInitArgs>(args: I): <P extends {
-	defineExtension: Function;
-	PrismaPromise: any;
+	defineExtension: typeof PrismaDefault.Prisma.defineExtension;
+	PrismaPromise: typeof PrismaDefault.Prisma.PrismaPromise;
 }>(Prisma: P) => (client: any) => PrismaDefault.PrismaClientExtends<Types.Extensions.InternalArgs<{}, {
 	readonly [K in (I['modelNames'] extends ReadonlyArray<infer U> ? U : never)]: BarkMethods<P['PrismaPromise']>
 }, {}, {}> & Types.Extensions.InternalArgs<{}, {}, {}, {}> & Types.Extensions.DefaultArgs>;


### PR DESCRIPTION
## Why
- Currently, bark hardcodes the generated path location. So it will blow up with not found if we set a custom generated file location.
- Fixes https://github.com/adamjkb/bark/issues/87

## What
- Refactor this codebase so it does not depend on runtime Prisma deps. Only the types
- Caller is required to pass in their own `Prisma` object